### PR TITLE
[nrf temphack] clean peripherals state before call the application

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -244,3 +244,9 @@ zephyr_library_sources(
   ${BOOT_DIR}/zephyr/arm_cleanup.c
 )
 endif()
+
+if(CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL)
+zephyr_library_sources(
+  ${BOOT_DIR}/zephyr/nrf_cleanup.c
+)
+endif()

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -141,6 +141,11 @@ config MCUBOOT_CLEANUP_ARM_CORE
 	depends on CPU_CORTEX_M
 	default y
 
+config MCUBOOT_NRF_CLEANUP_PERIPHERAL
+	bool "Perform peripheral cleanup before chain-load the application"
+	depends on SOC_FAMILY_NRF
+	default y
+
 config MBEDTLS_CFG_FILE
 	default "mcuboot-mbedtls-cfg.h"
 

--- a/boot/zephyr/include/nrf_cleanup.h
+++ b/boot/zephyr/include/nrf_cleanup.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef H_NRF_CLEANUP_
+#define H_NRF_CLEANUP_
+
+/**
+ * Perform cleanup on some peripheral resources used by MCUBoot prior chainload
+ * the application.
+ *
+ * This function disables all RTC instances and UARTE instances.
+ * It Disables their interrupts signals as well.
+ */
+void nrf_cleanup_peripheral(void);
+
+#endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -82,6 +82,11 @@ K_SEM_DEFINE(boot_log_sem, 1, 1);
 #include <pm_config.h>
 
 #endif
+
+#if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL
+#include <nrf_cleanup.h>
+#endif
+
 #ifdef CONFIG_SOC_FAMILY_NRF
 #include <hal/nrf_power.h>
 
@@ -151,7 +156,9 @@ static void do_boot(struct boot_rsp *rsp)
     }
 #endif
 #endif
-
+#if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL
+    nrf_cleanup_peripheral();
+#endif
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
     cleanup_arm_nvic(); /* cleanup NVIC registers */
 #endif

--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <hal/nrf_rtc.h>
+#include <hal/nrf_uarte.h>
+#include <hal/nrf_clock.h>
+
+#if defined(NRF_RTC0) || defined(NRF_RTC1) || defined(NRF_RTC2)
+static inline void nrf_cleanup_rtc(NRF_RTC_Type * rtc_reg)
+{
+    nrf_rtc_task_trigger(rtc_reg, NRF_RTC_TASK_STOP);
+    nrf_rtc_event_disable(rtc_reg, 0xFFFFFFFF);
+    nrf_rtc_int_disable(rtc_reg, 0xFFFFFFFF);
+}
+#endif
+
+static void nrf_cleanup_clock(void)
+{
+    nrf_clock_int_disable(NRF_CLOCK, 0xFFFFFFFF);
+}
+
+void nrf_cleanup_peripheral(void)
+{
+#if defined(NRF_RTC0)
+    nrf_cleanup_rtc(NRF_RTC0);
+#endif
+#if defined(NRF_RTC1)
+    nrf_cleanup_rtc(NRF_RTC1);
+#endif
+#if defined(NRF_RTC2)
+    nrf_cleanup_rtc(NRF_RTC2);
+#endif
+#if defined(NRF_UARTE0)
+    nrf_uarte_disable(NRF_UARTE0);
+    nrf_uarte_int_disable(NRF_UARTE0, 0xFFFFFFFF);
+#endif
+#if defined(NRF_UARTE1)
+    nrf_uarte_disable(NRF_UARTE1);
+    nrf_uarte_int_disable(NRF_UARTE1, 0xFFFFFFFF);
+#endif
+    nrf_cleanup_clock();
+}


### PR DESCRIPTION
Do some cleanup on NRF peripheral.

supersedes #88

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>