### PR TITLE
[nrf temphack] Ensure that MCUBoot read buffers are word aligned

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -69,7 +69,7 @@ static struct boot_loader_state boot_data;
  * to just make those variables stack allocated.
  */
 #if !defined(__BOOTSIM__)
-#define TARGET_STATIC static
+#define TARGET_STATIC __aligned(4) static
 #else
 #define TARGET_STATIC
 #endif


### PR DESCRIPTION
Since other flash drivers does not handle unaligned access yet, we
have to ensure that the read buffers are word aligned. We'll at most
throw away 6 bytes so I think it should be okei.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>