### PR TITLE
[nrf fromlist] cmake: use find_package to locate Zephyr

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -69,7 +69,7 @@ static struct boot_loader_state boot_data;
  * to just make those variables stack allocated.
  */
 #if !defined(__BOOTSIM__)
-#define TARGET_STATIC static
+#define TARGET_STATIC __aligned(4) static
 #else
 #define TARGET_STATIC
 #endif

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -39,9 +39,9 @@ macro(app_set_runner_args)
   endif()
 endmacro()
 
-# Standard Zephyr application boilerplate:
+# find_package(Zephyr) in order to load application boilerplate:
 # http://docs.zephyrproject.org/application/application.html
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 
 # Path to "boot" subdirectory of repository root.

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -39,9 +39,6 @@ macro(app_set_runner_args)
   endif()
 endmacro()
 
-# nRF Connect SDK application boilerplate, needed for out-of-tree Nordic boards.
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake NO_POLICY_SCOPE)
-
 # Standard Zephyr application boilerplate:
 # http://docs.zephyrproject.org/application/application.html
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)


### PR DESCRIPTION
 [nrf fromlist] cmake: use find_package to locate Zephyr

Using find_package to locate Zephyr.

Old behavior was to use $ENV{ZEPHYR_BASE} for inclusion of boiler plate
code.

Whenever an automatic run of CMake happend by the build system / IDE
then it was required that ZEPHYR_BASE was defined.
Using ZEPHYR_BASE only to locate the Zephyr package allows CMake to
cache the base variable and thus allowing subsequent invocation even
if ZEPHYR_BASE is not set in the environment.

It also removes the risk of strange build results if a user switchs
between different Zephyr based project folders and forgetting to reset
ZEPHYR_BASE before running ninja / make.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>