### PR TITLE
[nrf toup] zephyr: enable progressive erase on nrf53

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -245,7 +245,7 @@ config BOOT_MAX_IMG_SECTORS
 
 config BOOT_ERASE_PROGRESSIVELY
 	bool "Erase flash progressively when receiving new firmware"
-	default y if SOC_NRF52840 || SOC_NRF9160
+	default y if SOC_FAMILY_NRF
 	help
 	 If enabled, flash is erased as necessary when receiving new firmware,
 	 instead of erasing the whole image slot at once. This is necessary


### PR DESCRIPTION
This fixes issue where mcumgr upload command would result in
device being deleted, but no new image being uploadet
due to timeout while waiting for erase operation.

Ref: NCSDK-5603
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>