### PR TITLE
[nrf fromtree] boot/zephyr: set VTOR to relay vector before chain-load

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -22,6 +22,7 @@
 #include <drivers/timer/system_timer.h>
 #include <usb/usb_device.h>
 #include <soc.h>
+#include <linker/linker-defs.h>
 
 #include "target.h"
 
@@ -113,16 +114,9 @@ void os_heap_init(void);
 
 #if defined(CONFIG_ARM)
 
-#ifdef CONFIG_BOOT_INTR_VEC_RELOC
-
 #ifdef CONFIG_SW_VECTOR_RELAY
 extern void *_vector_table_pointer;
-#define VTOR _vector_table_pointer
-#elif CONFIG_CPU_CORTEX_M_HAS_VTOR
-#define VTOR SCB->VTOR
 #endif
-
-#endif /* CONFIG_BOOT_INTR_VEC_RELOC */
 
 struct arm_vector_table {
     uint32_t msp;
@@ -176,8 +170,20 @@ static void do_boot(struct boot_rsp *rsp)
 #endif
 
 #ifdef CONFIG_BOOT_INTR_VEC_RELOC
-    VTOR = vt;
+#if defined(CONFIG_SW_VECTOR_RELAY)
+    _vector_table_pointer = vt;
+#ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
+    SCB->VTOR = (uint32_t)__vector_relay_table;
 #endif
+#elif defined(CONFIG_CPU_CORTEX_M_HAS_VTOR)
+    SCB->VTOR = (uint32_t)vt;
+#endif /* CONFIG_SW_VECTOR_RELAY */
+#else /* CONFIG_BOOT_INTR_VEC_RELOC */
+#if defined(CONFIG_CPU_CORTEX_M_HAS_VTOR) && defined(CONFIG_SW_VECTOR_RELAY)
+    _vector_table_pointer = _vector_start;
+    SCB->VTOR = (uint32_t)__vector_relay_table;
+#endif
+#endif /* CONFIG_BOOT_INTR_VEC_RELOC */
 
     __set_MSP(vt->msp);
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE


### PR DESCRIPTION
If software IRQ relay is enabled and VTOR is available,
the bootloader will switch from its real vector table
to the relay vector table before chain-loading to the
application.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>
Signed-off-by: Krzysztof Taborowski <krzysztof.taborowski@nordicsemi.no>
Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>