### PR TITLE
boot: zephyr: Use correct pm template

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -20,7 +20,7 @@ mcuboot_secondary:
     align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
     after: mcuboot_primary
 
-#ifndef CONFIG_BOOT_SWAP_USING_MOVE
+#if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_IMAGE_DFU)
 mcuboot_scratch:
   size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SCRATCH
   placement:


### PR DESCRIPTION
When single image DFU is used scratch is not needed.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>