### PR TITLE
boot: zephyr: nrf53 network core bootloader implementation

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -712,10 +712,9 @@ boot_validated_swap_type(struct boot_loader_state *state,
     swap_type = boot_swap_type_multi(BOOT_CURR_IMG(state));
     if (BOOT_IS_UPGRADE(swap_type)) {
         /* Boot loader wants to switch to the secondary slot.
-         * Ensure image is valid. This checks header, hash/signature and trailer
+         * Ensure image is valid.
          */
         rc = boot_validate_slot(state, BOOT_SECONDARY_SLOT, bs);
-	/* Check for network update type */
         if (rc == 1) {
             swap_type = BOOT_SWAP_TYPE_NONE;
         } else if (rc != 0) {
@@ -728,8 +727,8 @@ boot_validated_swap_type(struct boot_loader_state *state,
 	if (reset_addr > PM_nrf5340pdk_nrf5340_cpunet_B0N_ADDRESS) {
 		uint32_t fw_size = hdr->ih_img_size;
 
-		BOOT_LOG_INF("Starting netowrk core update");
-		rc = do_network_core_update(NULL, vtable, fw_size);
+		BOOT_LOG_INF("Starting network core update");
+		rc = do_network_core_update(vtable, fw_size);
 		if (rc != 0) {
 			swap_type = BOOT_SWAP_TYPE_FAIL;
 		} else {

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -724,7 +724,7 @@ boot_validated_swap_type(struct boot_loader_state *state,
 	vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
 	vtable = (uint32_t *)(vtable_addr);
 	reset_addr = vtable[1];
-	if (reset_addr > PM_nrf5340pdk_nrf5340_cpunet_B0N_ADDRESS) {
+	if (reset_addr > PM_CPUNET_B0N_ADDRESS) {
 		uint32_t fw_size = hdr->ih_img_size;
 
 		BOOT_LOG_INF("Starting network core update");

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -80,7 +80,15 @@ zephyr_library_sources(
   flash_map_extended.c
   os.c
   keys.c
-  )
+)
+
+zephyr_library_include_directories(
+	.
+)
+
+zephyr_library_sources(
+  nrf53_cpunet_ctl.c
+)
 
 if(NOT DEFINED CONFIG_FLASH_PAGE_LAYOUT)
   zephyr_library_sources(

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -82,13 +82,11 @@ zephyr_library_sources(
   keys.c
 )
 
-zephyr_library_include_directories(
-	.
-)
-
+if(CONFIG_SOC_SERIES_NRF53X)
 zephyr_library_sources(
   nrf53_cpunet_ctl.c
 )
+endif()
 
 if(NOT DEFINED CONFIG_FLASH_PAGE_LAYOUT)
   zephyr_library_sources(

--- a/boot/zephyr/include/nrf53_cpunet_ctl.h
+++ b/boot/zephyr/include/nrf53_cpunet_ctl.h
@@ -1,17 +1,14 @@
-
 /*
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef H_NRF53_CPUNET_CTL_
-#define H_NRF53_CPUNET_CTL_
-
-/**
- * Enable debug pins and uart output 
- */
-void enable_network_core_debug_pins(void);
+#ifndef __NRF53_CPUNET_CTL_H
+#define __NRF53_CPUNET_CTL_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Initiate a network core update
@@ -24,5 +21,14 @@ void enable_network_core_debug_pins(void);
  * @param len Length of the data which is to be copied into the network core.
  *
  */
-int do_network_core_update(void *addr, void *src_addr, size_t len);
+int do_network_core_update(void *src_addr, size_t len);
+
+/**
+ * Lock RAM used to communicate with network bootloader
+ */
+void lock_ipc_ram_with_spu();
+#ifdef __cplusplus
+}
 #endif
+
+#endif /* NRF53_CPUNET_CTL */

--- a/boot/zephyr/include/nrf53_cpunet_ctl.h
+++ b/boot/zephyr/include/nrf53_cpunet_ctl.h
@@ -1,0 +1,28 @@
+
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_NRF53_CPUNET_CTL_
+#define H_NRF53_CPUNET_CTL_
+
+/**
+ * Enable debug pins and uart output 
+ */
+void enable_network_core_debug_pins(void);
+
+/**
+ * Initiate a network core update
+ *
+ * @param addr Adress to PCD_CMD structure set to PCD_CMD_ADDRESS if not
+ *	       provided.
+ *
+ * @param src_addr Start address of the data which is to be copied into the
+ *		   network core.
+ * @param len Length of the data which is to be copied into the network core.
+ *
+ */
+int do_network_core_update(void *addr, void *src_addr, size_t len);
+#endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -108,6 +108,10 @@ static inline bool boot_skip_serial_recovery()
 }
 #endif
 
+#ifdef CONFIG_SOC_SERIES_NRF53X
+#include <nrf53_cpunet_ctl.h>
+#endif
+
 MCUBOOT_LOG_MODULE_REGISTER(mcuboot);
 
 void os_heap_init(void);
@@ -326,6 +330,9 @@ void main(void)
     BOOT_LOG_INF("Starting bootloader");
 
     os_heap_init();
+#if defined(CONFIG_SOC_SERIES_NRF53X) && defined(CONFIG_DEBUG)
+    enable_network_core_debug_pins();
+#endif
 
     ZEPHYR_BOOT_LOG_START();
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -330,10 +330,6 @@ void main(void)
     BOOT_LOG_INF("Starting bootloader");
 
     os_heap_init();
-#if defined(CONFIG_SOC_SERIES_NRF53X) && defined(CONFIG_DEBUG)
-    enable_network_core_debug_pins();
-#endif
-
     ZEPHYR_BOOT_LOG_START();
 
 #if (!defined(CONFIG_XTENSA) && defined(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL))
@@ -433,6 +429,9 @@ void main(void)
             ;
     }
 #endif /* USE_PARTITION_MANAGER && CONFIG_FPROTECT */
+#if defined(CONFIG_SOC_SERIES_NRF53X)
+    lock_ipc_ram_with_spu();
+#endif
 
     ZEPHYR_BOOT_LOG_STOP();
 

--- a/boot/zephyr/nrf53_cpunet_ctl.c
+++ b/boot/zephyr/nrf53_cpunet_ctl.c
@@ -1,0 +1,88 @@
+#include <zephyr.h>
+#include <hal/nrf_reset.h>
+#include <hal/nrf_spu.h>
+#include <dfu/pcd.h>
+#include <pm_config.h>
+#include "bootutil/bootutil_log.h"
+MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+
+int do_network_core_update(void *addr, void *src_addr, size_t len)
+{
+	struct pcd_cmd *rsp = (struct pcd_cmd *) PCD_RSP_ADDRESS;
+	if (addr == NULL) {
+		addr = (void *)PCD_CMD_ADDRESS;
+
+	}
+
+	struct pcd_cmd *cmd = (struct pcd_cmd *)addr;
+
+	rsp->magic = PCD_CMD_MAGIC_COPY;
+	cmd->magic = PCD_CMD_MAGIC_COPY;
+	cmd->src_addr = src_addr;
+	cmd->len = len;
+	cmd->offset = 0x10800;
+	nrf_spu_ramregion_set(NRF_SPU,
+			      APP_CORE_SRAM_SIZE/CONFIG_NRF_SPU_RAM_REGION_SIZE,
+			      true, NRF_SPU_MEM_PERM_READ, true);
+
+	nrf_reset_network_force_off(NRF_RESET, false);
+	BOOT_LOG_INF("Turned on network core");
+
+	while (rsp->magic == PCD_CMD_MAGIC_COPY)
+		;
+
+	if (rsp->magic == PCD_CMD_MAGIC_FAIL) {
+		BOOT_LOG_ERR("Network core update failed");
+		return -1;
+	}
+
+	nrf_reset_network_force_off(NRF_RESET, true);
+	BOOT_LOG_INF("Turned off network core");
+
+	return 0;
+}
+
+/* This should come from DTS, possibly an overlay. */
+#if defined(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPP)
+#define CPUNET_UARTE_PIN_TX  25
+#define CPUNET_UARTE_PIN_RX  26
+#define CPUNET_UARTE_PORT_TRX NRF_P0
+#define CPUNET_UARTE_PIN_RTS 10
+#define CPUNET_UARTE_PIN_CTS 12
+#elif defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP)
+#define CPUNET_UARTE_PIN_TX  1
+#define CPUNET_UARTE_PIN_RX  0
+#define CPUNET_UARTE_PORT_TRX NRF_P1
+#define CPUNET_UARTE_PIN_RTS 11
+#define CPUNET_UARTE_PIN_CTS 10
+#endif
+
+#if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
+#include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h>
+#else
+#define DEBUG_SETUP()
+#endif
+
+void enable_network_core_debug_pins(void)
+{
+	/* UARTE */
+	/* Assign specific GPIOs that will be used to get UARTE from
+	 * nRF5340 Network MCU.
+	 */
+	CPUNET_UARTE_PORT_TRX->PIN_CNF[CPUNET_UARTE_PIN_TX] =
+	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
+	CPUNET_UARTE_PORT_TRX->PIN_CNF[CPUNET_UARTE_PIN_RX] =
+	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
+	NRF_P0->PIN_CNF[CPUNET_UARTE_PIN_RTS] =
+	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
+	NRF_P0->PIN_CNF[CPUNET_UARTE_PIN_CTS] =
+	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
+
+	/* Route Bluetooth Controller Debug Pins */
+	DEBUG_SETUP();
+
+	/* Retain nRF5340 Network MCU in Secure domain (bus
+	 * accesses by Network MCU will have Secure attribute set).
+	 */
+	NRF_SPU->EXTDOMAIN[0].PERM = 1 << 4;
+}

--- a/boot/zephyr/nrf53_cpunet_ctl.c
+++ b/boot/zephyr/nrf53_cpunet_ctl.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <zephyr.h>
 #include <hal/nrf_reset.h>
 #include <hal/nrf_spu.h>
@@ -6,32 +12,47 @@
 #include "bootutil/bootutil_log.h"
 MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
 
-int do_network_core_update(void *addr, void *src_addr, size_t len)
+static void set_pcd_cmd_struct(void *src_addr, size_t len)
 {
-	struct pcd_cmd *rsp = (struct pcd_cmd *) PCD_RSP_ADDRESS;
-	if (addr == NULL) {
-		addr = (void *)PCD_CMD_ADDRESS;
-
-	}
-
-	struct pcd_cmd *cmd = (struct pcd_cmd *)addr;
-
-	rsp->magic = PCD_CMD_MAGIC_COPY;
+	struct pcd_cmd *cmd = (struct pcd_cmd *)PCD_CMD_ADDRESS;
 	cmd->magic = PCD_CMD_MAGIC_COPY;
 	cmd->src_addr = src_addr;
 	cmd->len = len;
 	cmd->offset = 0x10800;
-	nrf_spu_ramregion_set(NRF_SPU,
-			      APP_CORE_SRAM_SIZE/CONFIG_NRF_SPU_RAM_REGION_SIZE,
-			      true, NRF_SPU_MEM_PERM_READ, true);
+}
+
+static bool is_copying(void)
+{
+	struct pcd_cmd *cmd = (struct pcd_cmd *)PCD_CMD_ADDRESS;
+	if (cmd->magic == PCD_CMD_MAGIC_COPY) {
+		return true;
+	} 
+
+	return false;
+}
+
+static bool successful(void)
+{
+	struct pcd_cmd *cmd = (struct pcd_cmd *)PCD_CMD_ADDRESS;
+	if (cmd->magic != PCD_CMD_MAGIC_DONE) {
+		return false;
+	}
+	return true;
+}
+
+int do_network_core_update(void *src_addr, size_t len)
+{
+	/* Ensure that the network core is turned off */
+	nrf_reset_network_force_off(NRF_RESET, true);
+	set_pcd_cmd_struct(src_addr, len);
 
 	nrf_reset_network_force_off(NRF_RESET, false);
 	BOOT_LOG_INF("Turned on network core");
 
-	while (rsp->magic == PCD_CMD_MAGIC_COPY)
+	while (is_copying())
 		;
 
-	if (rsp->magic == PCD_CMD_MAGIC_FAIL) {
+	if (!successful()) {
 		BOOT_LOG_ERR("Network core update failed");
 		return -1;
 	}
@@ -42,47 +63,8 @@ int do_network_core_update(void *addr, void *src_addr, size_t len)
 	return 0;
 }
 
-/* This should come from DTS, possibly an overlay. */
-#if defined(CONFIG_BOARD_NRF5340PDK_NRF5340_CPUAPP)
-#define CPUNET_UARTE_PIN_TX  25
-#define CPUNET_UARTE_PIN_RX  26
-#define CPUNET_UARTE_PORT_TRX NRF_P0
-#define CPUNET_UARTE_PIN_RTS 10
-#define CPUNET_UARTE_PIN_CTS 12
-#elif defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP)
-#define CPUNET_UARTE_PIN_TX  1
-#define CPUNET_UARTE_PIN_RX  0
-#define CPUNET_UARTE_PORT_TRX NRF_P1
-#define CPUNET_UARTE_PIN_RTS 11
-#define CPUNET_UARTE_PIN_CTS 10
-#endif
-
-#if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
-#include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h>
-#else
-#define DEBUG_SETUP()
-#endif
-
-void enable_network_core_debug_pins(void)
-{
-	/* UARTE */
-	/* Assign specific GPIOs that will be used to get UARTE from
-	 * nRF5340 Network MCU.
-	 */
-	CPUNET_UARTE_PORT_TRX->PIN_CNF[CPUNET_UARTE_PIN_TX] =
-	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
-	CPUNET_UARTE_PORT_TRX->PIN_CNF[CPUNET_UARTE_PIN_RX] =
-	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
-	NRF_P0->PIN_CNF[CPUNET_UARTE_PIN_RTS] =
-	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
-	NRF_P0->PIN_CNF[CPUNET_UARTE_PIN_CTS] =
-	GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos;
-
-	/* Route Bluetooth Controller Debug Pins */
-	DEBUG_SETUP();
-
-	/* Retain nRF5340 Network MCU in Secure domain (bus
-	 * accesses by Network MCU will have Secure attribute set).
-	 */
-	NRF_SPU->EXTDOMAIN[0].PERM = 1 << 4;
+void lock_ipc_ram_with_spu(){
+	nrf_spu_ramregion_set(NRF_SPU,
+			      APP_CORE_SRAM_SIZE/CONFIG_NRF_SPU_RAM_REGION_SIZE,
+			      true, NRF_SPU_MEM_PERM_READ, true);
 }


### PR DESCRIPTION
Enables network core updates of nrf53 using MCUBoot by identifying
images through their start addresses. Also implements the control and
transfer using the PCD module.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>