### PR TITLE
boot: zephyr: nrf53 network core bootloader implementation

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -45,6 +45,10 @@
 #include "bootutil/security_cnt.h"
 #include "bootutil/boot_record.h"
 
+#ifdef CONFIG_SOC_NRF5340_CPUAPP
+#include <dfu/pcd.h> 
+#endif
+
 #ifdef MCUBOOT_ENC_IMAGES
 #include "bootutil/enc_key.h"
 #endif
@@ -721,7 +725,15 @@ boot_validated_swap_type(struct boot_loader_state *state,
 {
     int swap_type;
     int rc;
-#ifdef PM_S1_ADDRESS
+    bool upgrade_valid = false;
+
+#if defined(PM_S1_ADDRESS) || defined(CONFIG_SOC_NRF5340_CPUAPP)
+    const struct flash_area *secondary_fa =
+        BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT);
+    struct image_header *hdr = (struct image_header *)secondary_fa->fa_off;
+    uint32_t vtable_addr = 0;
+    uint32_t *vtable = 0;
+    uint32_t reset_addr = 0;
     /* Patch needed for NCS. Since image 0 (the app) and image 1 (the other
      * B1 slot S0 or S1) share the same secondary slot, we need to check
      * whether the update candidate in the secondary slot is intended for
@@ -729,33 +741,30 @@ boot_validated_swap_type(struct boot_loader_state *state,
      * vector. Note that there are good reasons for not using img_num from
      * the swap info.
      */
-    const struct flash_area *secondary_fa =
-	    BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT);
-    struct image_header *hdr =
-	    (struct image_header *)secondary_fa->fa_off;
 
     if (hdr->ih_magic == IMAGE_MAGIC) {
-	    const struct flash_area *primary_fa;
-	    uint32_t vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
-	    uint32_t *vtable = (uint32_t *)(vtable_addr);
-	    uint32_t reset_addr = vtable[1];
-	    rc = flash_area_open(
-			    flash_area_id_from_multi_image_slot(
-				    BOOT_CURR_IMG(state),
-				    BOOT_PRIMARY_SLOT),
-			    &primary_fa);
-	    if (rc != 0) {
-		    return BOOT_SWAP_TYPE_FAIL;
-	    }
-	    /* Get start and end of primary slot for current image */
-	    if (reset_addr < primary_fa->fa_off ||
-	        reset_addr > (primary_fa->fa_off + primary_fa->fa_size)) {
-		    /* The image in the secondary slot is not intended for this image
-		    */
-		    return BOOT_SWAP_TYPE_NONE;
-	    }
+        vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
+        vtable = (uint32_t *)(vtable_addr);
+        reset_addr = vtable[1];
+#ifdef PM_S1_ADDRESS
+        const struct flash_area *primary_fa;
+        rc = flash_area_open(flash_area_id_from_multi_image_slot(
+                    BOOT_CURR_IMG(state),
+                    BOOT_PRIMARY_SLOT),
+                &primary_fa);
+        if (rc != 0) {
+            return BOOT_SWAP_TYPE_FAIL;
+        }
+        /* Get start and end of primary slot for current image */
+        if (reset_addr < primary_fa->fa_off ||
+                reset_addr > (primary_fa->fa_off + primary_fa->fa_size)) {
+            /* The image in the secondary slot is not intended for this image
+            */
+            return BOOT_SWAP_TYPE_NONE;
+        }
+#endif /* PM_S1_ADDRESS */
     }
-#endif
+#endif /* PM_S1_ADDRESS || CONFIG_SOC_NRF5340_CPUAPP */
 
     swap_type = boot_swap_type_multi(BOOT_CURR_IMG(state));
     if (BOOT_IS_UPGRADE(swap_type)) {
@@ -767,7 +776,30 @@ boot_validated_swap_type(struct boot_loader_state *state,
             swap_type = BOOT_SWAP_TYPE_NONE;
         } else if (rc != 0) {
             swap_type = BOOT_SWAP_TYPE_FAIL;
+        } else if (rc == 0) {
+            upgrade_valid = true;
         }
+
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS)
+        /* If the update is valid, and it targets the network core: perform the
+         * update and indicate to the caller of this function that no update is
+         * available
+         */
+        if (upgrade_valid && reset_addr > PM_CPUNET_B0N_ADDRESS) {
+            uint32_t fw_size = hdr->ih_img_size;
+
+            BOOT_LOG_INF("Starting network core update");
+            rc = pcd_network_core_update(vtable, fw_size);
+            if (rc != 0) {
+                swap_type = BOOT_SWAP_TYPE_FAIL;
+            } else {
+                BOOT_LOG_INF("Done updating network core");
+                rc = swap_erase_trailer_sectors(state,
+                        secondary_fa);
+                swap_type = BOOT_SWAP_TYPE_NONE;
+            }
+        }
+#endif /* CONFIG_SOC_NRF5340_CPUAPP */
     }
 
     return swap_type;

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -53,6 +53,10 @@ const struct boot_uart_funcs boot_funcs = {
 #include <arm_cleanup.h>
 #endif
 
+#ifdef CONFIG_SOC_NRF5340_CPUAPP
+#include <dfu/pcd.h>
+#endif
+
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_IMMEDIATE)
 #ifdef CONFIG_LOG_PROCESS_THREAD
 #warning "The log internal thread for log processing can't transfer the log"\
@@ -435,6 +439,9 @@ void main(void)
             ;
     }
 #endif /* USE_PARTITION_MANAGER && CONFIG_FPROTECT */
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS)
+    pcd_lock_ram();
+#endif
 
     ZEPHYR_BOOT_LOG_STOP();
 


### PR DESCRIPTION
Enables network core updates of nrf53 using MCUBoot by identifying
images through their start addresses. Also implements the control and
transfer using the PCD module.

Pulled in by https://github.com/nrfconnect/sdk-nrf/pull/2783

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>