### PR TITLE
zephyr/Kconfig: remove SINGLE_IMAGE_DFU duplication

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -148,6 +148,19 @@ endif
 
 endchoice
 
+config BOOT_SIGNATURE_KEY_FILE
+	string "PEM key file"
+	default "root-rsa-2048.pem"
+	help
+	  You can use either absolute or relative path.
+	  In case relative path is used, the build system assumes that it starts
+	  from the directory where the MCUBoot KConfig configuration file is
+	  located. If the key file is not there, the build system uses relative
+	  path that starts from the MCUBoot repository root directory.
+	  The key file will be parsed by imgtool's getpub command and a .c source
+	  with the public key information will be written in a format expected by
+	  MCUboot.
+
 config MCUBOOT_CLEANUP_ARM_CORE
 	bool "Perform core cleanup before chain-load the application"
 	depends on CPU_CORTEX_M

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -52,12 +52,4 @@ config DT_FLASH_WRITE_BLOCK_SIZE
 	int
 	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_FLASH),write-block-size)
 
-config SINGLE_IMAGE_DFU
-	bool "Single image application"
-	default n
-	help
-	  Single slot is used for application which means that uploading
-	  new application overwrites the one that previously occupied
-	  the slot.
-
 endmenu

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -35,19 +35,6 @@ config MCUBOOT_FLASH_WRITE_BLOCK_SIZE
 
 endif # BOOTLOADER_MCUBOOT
 
-config BOOT_SIGNATURE_KEY_FILE
-	string "PEM key file"
-	default "root-rsa-2048.pem"
-	help
-	  You can use either absolute or relative path.
-	  In case relative path is used, the build system assumes that it starts
-	  from the directory where the MCUBoot KConfig configuration file is
-	  located. If the key file is not there, the build system uses relative
-	  path that starts from the MCUBoot repository root directory.
-	  The key file will be parsed by imgtool's getpub command and a .c source
-	  with the public key information will be written in a format expected by
-	  MCUboot.
-
 config DT_FLASH_WRITE_BLOCK_SIZE
 	int
 	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_FLASH),write-block-size)


### PR DESCRIPTION
SINGLE_IMAGE_DFU option is already defined in boot/zephyr/Kconfig.

Kconfig: move BOOT_SIGNATURE_KEY_FILE to its upstream location

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>