### PR TITLE
[nrf fromtree] doc: fix link to external page in PORTING

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -144,15 +144,14 @@ int     flash_area_id_to_multi_image_slot(int image_index, int area_id);
 needs to provide this pair of function.
 
 To configure the what functions are called when allocating/deallocating
-memory `mbed TLS` uses the following call [^1]:
+memory `mbed TLS` uses the following call:
 
 ```
 int mbedtls_platform_set_calloc_free (void *(*calloc_func)(size_t, size_t),
                                       void (*free_func)(void *));
 ```
 
-If your system already provides functions with compatible signatures, those
-can be used directly here, otherwise create new functions that glue to
-your `calloc/free` implementations.
-
-[^1]: ```https://tls.mbed.org/api/platform_8h.html```
+For reference see [mbed TLS platform.h](https://tls.mbed.org/api/platform_8h.html).
+If your system already provides functions with compatible signatures, those can
+be used directly here, otherwise create new functions that glue to your
+`calloc/free` implementations.


### PR DESCRIPTION
Remove a footnote that is not generating a proper link and add an inline link to the mbed TLS referece for platform.h. This also fixes a warning when running through recommonmark==0.6.0 because it is unable to parse the old syntax.

PR: JuulLabs-OSS/mcuboot#822