### PR TITLE
[nrf temphack] nrf_cleanup:  Guard includes behind #if defined()

### DIFF
--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
-#include <hal/nrf_rtc.h>
-#include <hal/nrf_uarte.h>
 #include <hal/nrf_clock.h>
+#if defined(NRF_UARTE0) || defined(NRF_UARTE1)
+    #include <hal/nrf_uarte.h>
+#endif
+#if defined(NRF_RTC0) || defined(NRF_RTC1) || defined(NRF_RTC2)
+    #include <hal/nrf_rtc.h>
+#endif
 
 #if defined(NRF_RTC0) || defined(NRF_RTC1) || defined(NRF_RTC2)
 static inline void nrf_cleanup_rtc(NRF_RTC_Type * rtc_reg)


### PR DESCRIPTION
To allow compilation on nRF51 which doesn't have any NRF_UARTE.
Related to 664b8ad8b05e9fac567eafcf9fe617303fb6aed6

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>