### PR TITLE
[nrf fromtree] fixed: swap-move, bootstrapping and fast overwrite mode

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -961,6 +961,13 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     const struct flash_area *fap_secondary_slot;
     uint8_t image_index;
 
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+    uint32_t sector;
+    uint32_t trailer_sz;
+    uint32_t off;
+    uint32_t sz;
+#endif
+
     (void)bs;
 
 #if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
@@ -988,14 +995,30 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
         rc = boot_erase_region(fap_primary_slot, size, this_size);
         assert(rc == 0);
 
-        size += this_size;
-
 #if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
-        if (size >= src_size) {
+        if ((size + this_size) >= src_size) {
+            size += src_size - size;
+            size += BOOT_WRITE_SZ(state) - (size % BOOT_WRITE_SZ(state));
             break;
         }
 #endif
+
+        size += this_size;
     }
+
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+    trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
+    sector = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT) - 1;
+    sz = 0;
+    do {
+        sz += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, sector);
+        off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, sector);
+        sector--;
+    } while (sz < trailer_sz);
+
+    rc = boot_erase_region(fap_primary_slot, off, sz);
+    assert(rc == 0);
+#endif
 
 #ifdef MCUBOOT_ENC_IMAGES
     if (IS_ENCRYPTED(boot_img_hdr(state, BOOT_SECONDARY_SLOT))) {
@@ -1015,6 +1038,16 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     BOOT_LOG_INF("Copying the secondary slot to the primary slot: 0x%zx bytes",
                  size);
     rc = boot_copy_region(state, fap_secondary_slot, fap_primary_slot, 0, 0, size);
+    if (rc != 0) {
+        return rc;
+    }
+
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+    rc = boot_write_magic(fap_primary_slot);
+    if (rc != 0) {
+        return rc;
+    }
+#endif
 
 #ifdef MCUBOOT_HW_ROLLBACK_PROT
     /* Update the stored security counter with the new image's security counter

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1601,7 +1601,14 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
          * have been updated in the previous function call.
          */
         rc = boot_read_image_headers(state, !boot_status_is_reset(bs), bs);
+#ifdef MCUBOOT_BOOTSTRAP
+        /* When bootstrapping it's OK to not have image magic in the primary slot */
+        if (rc != 0 && (BOOT_CURR_IMG(state) != BOOT_PRIMARY_SLOT ||
+                boot_check_header_erased(state, BOOT_PRIMARY_SLOT) != 0)) {
+#else
         if (rc != 0) {
+#endif
+
             /* Continue with next image if there is one. */
             BOOT_LOG_WRN("Failed reading image headers; Image=%u",
                     BOOT_CURR_IMG(state));

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -329,13 +329,11 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
     old_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx - 1);
 
     if (bs->idx == BOOT_STATUS_IDX_0) {
-        if (bs->source != BOOT_STATUS_SOURCE_PRIMARY_SLOT) {
-            rc = swap_erase_trailer_sectors(state, fap_pri);
-            assert(rc == 0);
+        rc = swap_erase_trailer_sectors(state, fap_pri);
+        assert(rc == 0);
 
-            rc = swap_status_init(state, fap_pri, bs);
-            assert(rc == 0);
-        }
+        rc = swap_status_init(state, fap_pri, bs);
+        assert(rc == 0);
 
         rc = swap_erase_trailer_sectors(state, fap_sec);
         assert(rc == 0);


### PR DESCRIPTION
* fix swap-move brick with padded image0

When the image in the primary slot is padded, the boot source is
considered the primary slot; this results in skipping the typical
initialization of the trailer, which ends up bricking the device. As
it is fine to always initialize the trailer in the primary slot when
starting a new upgrade the extra check was removed.

* fix boostrapping in swap-move

Fix boostrapping in swap-move that was being skipped due to the having
an erased header in the primary slot which caused an early return
because of the requirement of having to re-read image headers when
"moving" an image during an upgrade.

* copy image size with fast overwrite 

Previously when `MCUBOOT_OVERWRITE_ONLY_FAST` was set, the whole amount
of sectors that stored an image were being copied. After this commit
only the exact amount of data used by the image is copied; this avoids
copying some 0xff (or garbage) data between the end of the image and the
end of the last sector storing it.

Extra trailer management was added which suits using the copy upgrade
routine also for bootstrapping.

Signed-off-by: Fabio Utzig <fabio.utzig@nordicsemi.no>
Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>