### PR TITLE
[nrf temphack] Kconfig: select 8-bits flash access for recovery mode

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -376,6 +376,7 @@ menuconfig MCUBOOT_SERIAL
 	select UART_INTERRUPT_DRIVEN
 	select BASE64
 	select TINYCBOR
+	select SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS if SOC_FLASH_NRF
 	help
 	  If y, enables a serial-port based update mode. This allows
 	  MCUboot itself to load update images into flash over a UART.


### PR DESCRIPTION
Serial recovery protocol doesn't care about writing data in block
of multiples flash write-block-sizes. Therefore the last payload block
which might be not aligned which imposes the flash write alignment error.

This patch select 8-bits access emulation which solves the issue.

Fixes NCSDK-6751

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>