### PR TITLE
[nrf noup] Kconfig: create duplicate of sign key

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -33,6 +33,25 @@ config MCUBOOT_FLASH_WRITE_BLOCK_SIZE
 	int
 	default $(dt_node_int_prop_int,$(DT_CHOSEN_ZEPHYR_FLASH),write-block-size)
 
+config BOOT_SIGNATURE_KEY_FILE
+	# Duplicate from boot/zephyr/Kconfig to expose this option to the parent
+	# image. Without this copy, it is not possible for the parent image to
+	# be signed if the MCUBoot child image is not built from source.
+	string "PEM key file"
+	default "root-ec-p256.pem" if BOOT_SIGNATURE_TYPE_ECDSA_P256
+	default "root-ed25519.pem" if BOOT_SIGNATURE_TYPE_ED25519
+	default "root-rsa-3072.pem" if BOOT_SIGNATURE_TYPE_RSA && BOOT_SIGNATURE_TYPE_RSA_LEN=3072
+	default "root-rsa-2048.pem" if BOOT_SIGNATURE_TYPE_RSA && BOOT_SIGNATURE_TYPE_RSA_LEN=2048
+	help
+	  You can use either absolute or relative path.
+	  In case relative path is used, the build system assumes that it starts
+	  from the directory where the MCUBoot KConfig configuration file is
+	  located. If the key file is not there, the build system uses relative
+	  path that starts from the MCUBoot repository root directory.
+	  The key file will be parsed by imgtool's getpub command and a .c source
+	  with the public key information will be written in a format expected by
+	  MCUboot.
+
 endif # BOOTLOADER_MCUBOOT
 
 config DT_FLASH_WRITE_BLOCK_SIZE


### PR DESCRIPTION
This duplicate is needed for the parent image to have access
to the signing key when MCUBoot is not built from source.

Ref: NCSDK-6859
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>