### PR TITLE
[nrf noup] pm: remove dependency on devicetree

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -1,5 +1,4 @@
 #include <autoconf.h>
-#include <devicetree_legacy_unfixed.h>
 
 mcuboot:
   size: CONFIG_PM_PARTITION_SIZE_MCUBOOT
@@ -17,7 +16,7 @@ mcuboot_primary:
 mcuboot_secondary:
   share_size: [mcuboot_primary]
   placement:
-    align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
+    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
     after: mcuboot_primary
 
 #if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_IMAGE_DFU)
@@ -25,7 +24,7 @@ mcuboot_scratch:
   size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SCRATCH
   placement:
     after: app
-    align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
+    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 #endif
 
 # Padding placed before image to boot


### PR DESCRIPTION
The symbols we need are already available in kconfig

Ref: NCSDK-7150
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>