### PR TITLE
[nrf temphack] nrf_cleanup: Stop HFCLK and LFCLK before boot

### DIFF
--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -23,6 +23,8 @@ static inline void nrf_cleanup_rtc(NRF_RTC_Type * rtc_reg)
 
 static void nrf_cleanup_clock(void)
 {
+    nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_LFCLKSTOP);
+    nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTOP);
     nrf_clock_int_disable(NRF_CLOCK, 0xFFFFFFFF);
 }
 


### PR DESCRIPTION
Change adds stopping HFCLK and LFCLK before boot. This speeds up Zephyr application's boot time if MCUBoot uses XTAL as 32KHz clock source.