### PR TITLE
mcuboot: Don't create second image partition in single slot build

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -13,11 +13,15 @@ mcuboot_primary_app:
 mcuboot_primary:
   span: [mcuboot_pad, mcuboot_primary_app]
 
+# Partition for secondary slot is not created if building in single applicaton
+# slot configuration.
+#if !defined(CONFIG_SINGLE_APPLICATION_SLOT)
 mcuboot_secondary:
   share_size: [mcuboot_primary]
   placement:
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
     after: mcuboot_primary
+#endif
 
 #if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_APPLICATION_SLOT)
 mcuboot_scratch:


### PR DESCRIPTION
This commit sets size of second image partition to zero if CONFIG_SINGLE_APPLICATION_SLOT=y, hence the secondary image partition is dropped by partition manager. This allows to use available flash to have bigger slot image without unnecessary workarounds.


Tested with Zigbee samples, mcuboot main() extended to print size and offset of the slot_0 after startup:
`printk("image_0 offset: 0x%x\n", FLASH_AREA_OFFSET(image_0));`
`printk("image_0 size:   0x%x\n", FLASH_AREA_SIZE(image_0));`

Zigbee sample built with:
`west build -b nrf52840dk_nrf52840 --pristine -s ~/GIT/ncs/nrf/samples/zigbee/light_switch -- -Dmcuboot_OVERLAY_CONFIG="usb_cdc_acm_log_recovery.conf single_slot.conf" -DCONFIG_BOOTLOADER_MCUBOOT=y -DPM_STATIC_YML_FILE=/home/sedr/GIT/ncs/nrf/samples/zigbee/ncp/configuration/nrf52840dk_nrf52840/pm_static.yml`
, pm_static.yml used to increase mcuboot partition size:
```
 mcuboot:
   address: 0x0
   end_address: 0x10000
   region: flash_primary
   size: 0x10000
```

mcuboot flashed to nrf52840 board, reported correct image_0 size and offset (compared with partitions.yaml):
```
*** Booting Zephyr OS build v2.4.0-ncs1-3484-g21046b8cdb4e  ***
I: Starting bootloader
image_0 offset: 0x10000
image_0 size:   0xe1000
I: Enter the serial recovery mode
I: Device suspended
I: Device resumed
I: from suspend
```
Zigbee light switch image app_update.bin uploaded with mcumgr, booted corectly after reset.
`./mcumgr -t 5 --conntype serial --connstring=/dev/ttyACM2 image upload  ~/GIT/ncs/nrf/build/zephyr/app_update.bin`

2nd image upload tested with different Zigbee sample:
`west build -b nrf52840dk_nrf52840 --pristine -s ~/GIT/ncs/nrf/samples/zigbee/light_bulb -- -Dmcuboot_OVERLAY_CONFIG="usb_cdc_acm_log_recovery.conf single_slot.conf" -DCONFIG_BOOTLOADER_MCUBOOT=y -DPM_STATIC_YML_FILE=/home/sedr/GIT/ncs/nrf/samples/zigbee/ncp/configuration/nrf52840dk_nrf52840/pm_static.yml`

Board reset with button_0 pressed to enter recovery, new image uploaded with mcumgr. After reset, sample booted correctly.