### PR TITLE
[nrf temphack] bootutil: loader: Fix multi-image variant builds

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1404,7 +1404,7 @@ boot_verify_dependencies(struct boot_loader_state *state)
         if (rc == 0) {
             /* All dependencies've been satisfied, continue with next image. */
             BOOT_CURR_IMG(state)++;
-        } else {
+	} else if (rc == BOOT_EBADIMAGE) {
             /* Cannot upgrade due to non-met dependencies, so disable all
              * image upgrades.
              */
@@ -1413,7 +1413,10 @@ boot_verify_dependencies(struct boot_loader_state *state)
                 BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_NONE;
             }
             break;
-        }
+	} else {
+	    /* Other error happened, images are inconsistent */
+		return rc;
+	}
     }
     return rc;
 }


### PR DESCRIPTION
Seems multi-image dependencies are not supported for multi-image in NCS
yet. This is a hack which reverts it to how it worked previously in
MCUboot. So that Immutable bootloader + MCUBoot type of builds will work
again.

Ref. NCSDK-8681

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>