### PR TITLE
Fixed serial dfu using usb

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -626,6 +626,7 @@ boot_serial_start(const struct boot_uart_funcs *f)
     while (1) {
         rc = f->read(in_buf + off, sizeof(in_buf) - off, &full_line);
         if (rc <= 0 && !full_line) {
+            k_yield();
             continue;
         }
         off += rc;


### PR DESCRIPTION
It is not possible to use BOOT_SERIAL_CDC_ACM at the moment as the USB handling is not given an opportunity to run after entering serial recovery mode.

I don't know if this is a good solution, but since I could not open an issue I thought I would share how I got it working, if for no other reason than to inform you of the issue.

Signed-off-by: Albert Juhl [aj@lcmveloci.com](aj@lcmveloci.com)