### PR TITLE
[nrf noup] pm: BOOT_UPGRADE_ONLY doesn't need scratch area

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -13,7 +13,7 @@ mcuboot_primary_app:
 mcuboot_primary:
   span: [mcuboot_pad, mcuboot_primary_app]
 
-# Partition for secondary slot is not created if building in single applicaton
+# Partition for secondary slot is not created if building in single application
 # slot configuration.
 #if !defined(CONFIG_SINGLE_APPLICATION_SLOT)
 mcuboot_secondary:
@@ -23,7 +23,7 @@ mcuboot_secondary:
     after: mcuboot_primary
 #endif
 
-#if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_APPLICATION_SLOT)
+#if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_APPLICATION_SLOT) && !defined(CONFIG_BOOT_UPGRADE_ONLY)
 mcuboot_scratch:
   size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SCRATCH
   placement:


### PR DESCRIPTION
Scratch area was declared for BOOT_UPGRADE_ONLY unnecessarily.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>