### PR TITLE
Fix signature validation on external crypto

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/ecdsa_p256.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa_p256.h
@@ -184,6 +184,17 @@ static inline int bootutil_ecdsa_p256_verify(bootutil_ecdsa_p256_context *ctx,
     (void)ctx;
     (void)pk_len;
     (void)sig_len;
+
+	/* As described on the compact representation in IETF protocols,
+	 * the first byte of the key defines if the ECC points are
+	 * compressed (0x2 or 0x3) or uncompressed (0x4).
+	 * We only support uncompressed keys.
+	 */
+	if (pk[0] != 0x04)
+		return -1;
+
+	pk++;
+
     return bl_secp256r1_validate(hash, BOOTUTIL_CRYPTO_ECDSA_P256_HASH_SIZE,
                                  pk, sig);
 }


### PR DESCRIPTION
-When mcuboot was used with external crypto for firmware
 validation it fails to remove the compression byte from
 the key so it fails the validation. This removes the
 byte as needed.

sdk-nrf PR: [pull/4700](https://github.com/nrfconnect/sdk-nrf/pull/4700)

Downstream commit with function addition: [48aee5f6](https://github.com/nrfconnect/sdk-mcuboot/commit/48aee5f6)

Ref: NCSDK-9848

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>