### PR TITLE
[nrf noup] mcuboot: Only include pcd.h if the nRF53 network core is being upgraded

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -45,7 +45,7 @@
 #include "bootutil/boot_record.h"
 #include "bootutil/fault_injection_hardening.h"
 
-#ifdef CONFIG_SOC_NRF5340_CPUAPP
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(CONFIG_NRF53_UPGRADE_NETWORK_CORE)
 #include <dfu/pcd.h> 
 #endif
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -56,7 +56,7 @@ const struct boot_uart_funcs boot_funcs = {
 #include <arm_cleanup.h>
 #endif
 
-#ifdef CONFIG_SOC_NRF5340_CPUAPP
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(CONFIG_NRF53_UPGRADE_NETWORK_CORE)
 #include <dfu/pcd.h>
 #endif
 


### PR DESCRIPTION
Only include pcd.h in mcuboot when CONFIG_NRF53_UPGRADE_NETWORK_CORE is defined

ref: NCSDK-7433

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>