### PR TITLE
fixup! [nrf noup] treewide: add NCS partition manager support

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -25,6 +25,7 @@ mcuboot_secondary:
 #else
   placement:
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
+    align_next: CONFIG_FPROTECT_BLOCK_SIZE # Ensure that the next partition does not interfere with this image
     after: mcuboot_primary
 #endif /* CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY */
 #endif /* !defined(CONFIG_SINGLE_APPLICATION_SLOT) */


### PR DESCRIPTION
Will be squashed

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Change slot alignment to avoid problems in some cases

We cannot align on both end and start, so to ensure that the start
of primary, start of secondary and end of secondary are all aligned, we now use the
new 'align_next' partition manager directive.