### PR TITLE
[nrf noup] partition_manager: improve support for external flash 

### DIFF
--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -16,6 +16,8 @@
 
 #elif (MCUBOOT_IMAGE_NUMBER == 2)
 
+#ifdef CONFIG_SECURE_BOOT
+
 extern uint32_t _image_1_primary_slot_id[];
 
 #define FLASH_AREA_IMAGE_PRIMARY(x)            \
@@ -31,6 +33,24 @@ extern uint32_t _image_1_primary_slot_id[];
         (x == 1) ?                    \
            PM_MCUBOOT_SECONDARY_ID:   \
            255 )
+#else
+
+#define FLASH_AREA_IMAGE_PRIMARY(x)          \
+        ((x == 0) ?                          \
+           PM_MCUBOOT_PRIMARY_ID :           \
+         (x == 1) ?                          \
+           PM_MCUBOOT_PRIMARY_1_ID :         \
+           255 )
+
+#define FLASH_AREA_IMAGE_SECONDARY(x) \
+        ((x == 0) ?                   \
+           PM_MCUBOOT_SECONDARY_ID:   \
+        (x == 1) ?                    \
+           PM_MCUBOOT_SECONDARY_1_ID: \
+           255 )
+
+#endif /* CONFIG_SECURE_BOOT */
+
 #endif
 #define FLASH_AREA_IMAGE_SCRATCH    PM_MCUBOOT_SCRATCH_ID
 

--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -17,11 +17,18 @@ mcuboot_primary:
 # slot configuration.
 #if !defined(CONFIG_SINGLE_APPLICATION_SLOT)
 mcuboot_secondary:
+#if defined(CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY)
+  region: external_flash
+  size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY
+  placement:
+    align: {start: 4}
+#else
   share_size: [mcuboot_primary]
   placement:
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
     after: mcuboot_primary
-#endif
+#endif /* CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY */
+#endif /* !defined(CONFIG_SINGLE_APPLICATION_SLOT) */
 
 #if !defined(CONFIG_BOOT_SWAP_USING_MOVE) && !defined(CONFIG_SINGLE_APPLICATION_SLOT) && !defined(CONFIG_BOOT_UPGRADE_ONLY)
 mcuboot_scratch:

--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -49,3 +49,14 @@ mcuboot_pad:
 #ifdef CONFIG_FPROTECT
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 #endif
+
+#if (CONFIG_NRF53_MULTI_IMAGE_UPDATE)
+mcuboot_primary_1:
+  region: ram_flash
+  size: CONFIG_NRF53_RAM_FLASH_SIZE
+
+mcuboot_secondary_1:
+  region: external_flash
+  size: CONFIG_NRF53_RAM_FLASH_SIZE
+
+#endif /* CONFIG_NRF53_MULTI_IMAGE_UPDATE */


### PR DESCRIPTION
Improve the user experience by leveraging a new kconfig option
which indicates that the MCUboot secondary slot should be stored
in external flash region.

Ref: NCSDK-10375

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>