### PR TITLE
[nrf fromtree] Allow to boot primary image if secondary one is unreachable

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -96,6 +96,7 @@ extern "C" {
 #define BOOT_ENOMEM      6
 #define BOOT_EBADARGS    7
 #define BOOT_EBADVERSION 8
+#define BOOT_EFLASH_SEC  9
 
 #define BOOT_HOOK_REGULAR 1
 /*

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -432,7 +432,15 @@ boot_swap_type_multi(int image_index)
 
     rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SECONDARY(image_index),
                                     &secondary_slot);
-    if (rc) {
+    if (rc == BOOT_EFLASH) {
+        BOOT_LOG_INF("Secondary image of image pair (%d.) "
+                     "is unreachable. Treat it as empty", image_index);
+        secondary_slot.magic = BOOT_MAGIC_UNSET;
+        secondary_slot.swap_type = BOOT_SWAP_TYPE_NONE;
+        secondary_slot.copy_done = BOOT_FLAG_UNSET;
+        secondary_slot.image_ok = BOOT_FLAG_UNSET;
+        secondary_slot.image_num = 0;
+    } else if (rc) {
         return BOOT_SWAP_TYPE_PANIC;
     }
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -381,7 +381,8 @@ boot_read_sectors(struct boot_loader_state *state)
 
     rc = boot_initialize_area(state, FLASH_AREA_IMAGE_SECONDARY(image_index));
     if (rc != 0) {
-        return BOOT_EFLASH;
+        /* We need to differentiate from the primary image issue */
+        return BOOT_EFLASH_SEC;
     }
 
 #if MCUBOOT_SWAP_USING_SCRATCH
@@ -1758,7 +1759,11 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
          * if there is one.
          */
         BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_NONE;
-        return;
+        if (rc == BOOT_EFLASH)
+        {
+            /* Only return on error from the primary image flash */
+            return;
+        }
     }
 
     /* Attempt to read an image header from each slot. */


### PR DESCRIPTION
Parent PR: https://github.com/mcu-tools/mcuboot/pull/1038

In case secondary image device has a malfunction,
It might be still possible to boot the primary image.

This make sense especially if the secondary image resides in an
external flash which might be damaged while SoC is still working.