### PR TITLE
[nrf noup] boot: limited pcd routines calls to network core update

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -46,7 +46,7 @@
 #include "bootutil/fault_injection_hardening.h"
 #include "bootutil/ramload.h"
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(CONFIG_NRF53_UPGRADE_NETWORK_CORE)
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS)
 #include <dfu/pcd.h> 
 #endif
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -56,7 +56,7 @@ const struct boot_uart_funcs boot_funcs = {
 #include <arm_cleanup.h>
 #endif
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(CONFIG_NRF53_UPGRADE_NETWORK_CORE)
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS)
 #include <dfu/pcd.h>
 #endif
 


### PR DESCRIPTION
this is amendment to

https://github.com/nrfconnect/sdk-mcuboot/commit/d362b129cb18

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

fixes>
 

[57/300] Building C object CMakeFiles/app.dir/main.c.obj
/home/ludu/git/nrfconnect_chip/bootloader/mcuboot/boot/zephyr/main.c: In function 'main':
/home/ludu/git/nrfconnect_chip/bootloader/mcuboot/boot/zephyr/main.c:584:5: warning: implicit declaration of function 'pcd_lock_ram' [-Wimplicit-function-declaration]
  584 |     pcd_lock_ram();
      |     ^~~~~~~~~~~~
[96/300] Building C object CMakeFiles/app.dir/home/ludu/git/nrfconnect_chip/bootloader/mcuboot/boot/bootutil/src/loader.c.obj
/home/ludu/git/nrfconnect_chip/bootloader/mcuboot/boot/bootutil/src/loader.c: In function 'boot_validated_swap_type':
/home/ludu/git/nrfconnect_chip/bootloader/mcuboot/boot/bootutil/src/loader.c:933:22: warning: implicit declaration of function 'pcd_network_core_update' [-Wimplicit-function-declaration]
  933 |             int rc = pcd_network_core_update(vtable, fw_size);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~
[293/300] Linking C executable zephyr/zephyr_prebuilt.elf