### PR TITLE
[nrf fromlist] zephyr: Remove BOOT_SERIAL_UART dependency from ...

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -623,7 +623,6 @@ config BOOT_ERASE_PROGRESSIVELY
 
 menuconfig ENABLE_MGMT_PERUSER
 	bool "Enable system specific mcumgr commands"
-	depends on BOOT_SERIAL_UART
 	help
 	  The option enables processing of system specific mcumgr commands;
 	  system specific commands are within group MGMT_GROUP_ID_PERUSER (64)


### PR DESCRIPTION
... ENABLE_MGMT_PERUSER

The dependency, in Kconfig,  blocked usage of the ENABLE_MGMT_PERUSER
with other BOOT_SERIAL_ device options.

Upstream PR: https://github.com/mcu-tools/mcuboot/pull/1125

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>