### PR TITLE
[nrf noup] zephyr: pm: share size with primary in all cases

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -17,13 +17,12 @@ mcuboot_primary:
 # slot configuration.
 #if !defined(CONFIG_SINGLE_APPLICATION_SLOT)
 mcuboot_secondary:
+  share_size: [mcuboot_primary]
 #if defined(CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY)
   region: external_flash
-  size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY
   placement:
     align: {start: 4}
 #else
-  share_size: [mcuboot_primary]
   placement:
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
     after: mcuboot_primary


### PR DESCRIPTION
Leverage recently added support for sharing size across regions
in partition manager. This way it is no longer required to
manually specify the size of the MCUboot secondary partition
when it is stored in external flash.

Ref: NCSDK-10375
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>