### PR TITLE
[nrf noup] zephyr: Added TF-M present Kconfig

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -89,6 +89,12 @@ config BOOT_USE_NRF_EXTERNAL_CRYPTO
 	help
 	  Use Shared crypto for crypto primitives.
 
+config MCUBOOT_TFM_PRESENT
+	bool "TF-M is present"
+	help
+	  This option allows MCUBOOT perform configurations to allow
+	  compatibility with TF-M.
+
 menu "MCUBoot settings"
 
 config SINGLE_APPLICATION_SLOT


### PR DESCRIPTION
-Add a configuration to allow the MCUBOOT be
 aware that the TF-M will be present in the build.
 This is needed since FW_INFO is not available for
 TF-M and MCUBOOT enforces the use of the EXT_APIs.

Ref: NCSDK-12021

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>