### PR TITLE
[nrf fromlist] boo_serial: cleanup max output size calculation

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -68,7 +68,7 @@ MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
 #endif
 
 #define BOOT_SERIAL_INPUT_MAX   512
-#define BOOT_SERIAL_OUT_MAX     (128 * MCUBOOT_IMAGE_NUMBER)
+#define BOOT_SERIAL_OUT_MAX     (128 * BOOT_IMAGE_NUMBER)
 
 #ifdef __ZEPHYR__
 /* base64 lib encodes data to null-terminated string */


### PR DESCRIPTION
Calculation of BOOT_SERIAL_OUT_MAX was based on MCUBOOT_IMAGE_NUMBER
while in other places BOOT_IMAGE_NUMBER is taken int account as
images number. Let's align the calculation to use same literal value
as others.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>