### PR TITLE
[nrf fromtree] Include mcuboot_config.h from sign_key.h to fix MCUBOO…

### DIFF
--- a/boot/bootutil/include/bootutil/sign_key.h
+++ b/boot/bootutil/include/bootutil/sign_key.h
@@ -25,6 +25,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* mcuboot_config.h is needed for MCUBOOT_HW_KEY to work */
+#include "mcuboot_config/mcuboot_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
…T_HW_KEY compilation

fixes NCSIDB-659
original PR: https://github.com/mcu-tools/mcuboot/pull/1156

Signed-off-by: Maxime Vincent <maxime@veemax.be>
Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>