### PR TITLE
[nrf noup] boot: zephyr: Enable zeroize ALT func

### DIFF
--- a/boot/zephyr/include/mcuboot-mbedtls-cfg.h
+++ b/boot/zephyr/include/mcuboot-mbedtls-cfg.h
@@ -21,6 +21,16 @@
  * the simulator build.rs accordingly.
  */
 
+/*
+ * When the CC3XX_PLATFORM library is enabled we need to
+ * inform the Mbed TLS library to not compile the
+ * platform_zeroize function, otherwise we will get
+ * a multiple definitions error.
+ */
+#if defined(CONFIG_NRF_CC3XX_PLATFORM)
+#define MBEDTLS_PLATFORM_ZEROIZE_ALT
+#endif
+
 #if defined(CONFIG_BOOT_SIGNATURE_TYPE_RSA) || defined(CONFIG_BOOT_ENCRYPT_RSA)
 #include "config-rsa.h"
 #elif defined(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256) || \


### PR DESCRIPTION
-This enables the MBEDTLS_PLATFORM_ZEROIZE_ALT
 definition on Mbed TLS build of the MCUBOOT when
 the platform library is enabled. If not defined
 the Mbed TLS will compile the zeroize function
 and it will cause multiple definition errors.
 This is a noup because the configuration
 does not exist outside the sdk-nrf.

Ref: NCSDK-13503

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>