### PR TITLE
Copy magic to RAM before writing to flash

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -317,13 +317,17 @@ boot_write_magic(const struct flash_area *fap)
 {
     uint32_t off;
     int rc;
+    uint8_t magic[BOOT_MAGIC_SZ];
+
+    //some architectures cannot DMA directly from internal flash
+    memcpy(magic, boot_img_magic, BOOT_MAGIC_SZ);
 
     off = boot_magic_off(fap);
 
     BOOT_LOG_DBG("writing magic; fa_id=%d off=0x%lx (0x%lx)",
                  flash_area_get_id(fap), (unsigned long)off,
                  (unsigned long)(flash_area_get_off(fap) + off));
-    rc = flash_area_write(fap, off, boot_img_magic, BOOT_MAGIC_SZ);
+    rc = flash_area_write(fap, off, magic, BOOT_MAGIC_SZ);
     if (rc != 0) {
         return BOOT_EFLASH;
     }


### PR DESCRIPTION
## Description

Some architectures (e.g., EasyDMA on nRF52 and nRF91) cannot
DMA data directly from internal flash to an external SPI flash.
An -EIO error is returned if this is attempted.

For nRF52 with QSPI, this limitation can be avoided by using
a write buffer; i.e., enabling `CONFIG_NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE`
will first copy the data to a buffer in RAM before DMA'ing.

However, with the nRF91 for example, QSPI is not available, and the
generic NOR SPI driver does not support a write buffer.

This change allows writing the magic to flash, regardless of whether
or not a write buffer is enabled or available.  It also has negligible impact
on other architectures, as it is simply copying 4 words to RAM. 

Note that it is not possible to support the secondary image on external SPI flash
on the nRF91 without this change.

## How was this tested?
Tested on an nRF91 with a W25Q64 external SPI flash.  The following config was enabled
in order to use the external SPI flash for the `mcuboot_secondary` slot:
```
CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=y
```
A FOTA was performed.  Before the change, the `flash_area_write()` call in `boot_write_magic()` would fail with an `-EIO` error, due to `spi_nor_cmd_addr_write()` failing in spi_nor.c.

After this change, the magic was successfully written and FOTA completed successfully.
