### PR TITLE
[nrf fromtree] fix build with encryption and mbetls or tinycrypt

### DIFF
--- a/boot/bootutil/zephyr/CMakeLists.txt
+++ b/boot/bootutil/zephyr/CMakeLists.txt
@@ -42,4 +42,10 @@ endif()
 
 zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
 target_link_libraries(MCUBOOT_BOOTUTIL INTERFACE zephyr_interface)
+
+if(CONFIG_BOOT_USE_TINYCRYPT)
+target_include_directories(MCUBOOT_BOOTUTIL INTERFACE
+  ../../../ext/tinycrypt/lib/include
+)
+endif()
 endif()

--- a/boot/bootutil/zephyr/CMakeLists.txt
+++ b/boot/bootutil/zephyr/CMakeLists.txt
@@ -48,4 +48,8 @@ target_include_directories(MCUBOOT_BOOTUTIL INTERFACE
   ../../../ext/tinycrypt/lib/include
 )
 endif()
+
+if(CONFIG_BOOT_USE_MBEDTLS)
+  zephyr_link_libraries(mbedTLS)
+endif()
 endif()


### PR DESCRIPTION
I bring two upstream fixes for fix building with the image encryption enabled.

Content of:
https://github.com/mcu-tools/mcuboot/pull/1357
https://github.com/mcu-tools/mcuboot/pull/1358