### PR TITLE
[nrf toup] zephyr: Add overlay for external flash on thingy53

### DIFF
--- a/boot/zephyr/boards/thingy53_nrf5340_cpuapp.overlay
+++ b/boot/zephyr/boards/thingy53_nrf5340_cpuapp.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};


### PR DESCRIPTION
Add thingy53_nrf5340_cpuapp.overlay

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>