### PR TITLE
[nrf noup] bootutil: Fix missing PCD define check

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1012,7 +1012,7 @@ boot_validated_swap_type(struct boot_loader_state *state,
         }
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS) \
-    && !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE)
+    && !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE) && defined(CONFIG_PCD_APP)
         /* If the update is valid, and it targets the network core: perform the
          * update and indicate to the caller of this function that no update is
          * available
@@ -1040,7 +1040,8 @@ boot_validated_swap_type(struct boot_loader_state *state,
                 swap_type = BOOT_SWAP_TYPE_NONE;
             }
         }
-#endif /* CONFIG_SOC_NRF5340_CPUAPP */
+#endif /* CONFIG_SOC_NRF5340_CPUAPP && PM_CPUNET_B0N_ADDRESS &&
+	  !CONFIG_NRF53_MULTI_IMAGE_UPDATE && CONFIG_PCD_APP */
     }
 
     return swap_type;

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -730,7 +730,7 @@ int main(void)
             ;
     }
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS)
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS) && defined(CONFIG_PCD_APP)
     pcd_lock_ram();
 #endif
 #endif /* USE_PARTITION_MANAGER && CONFIG_FPROTECT */


### PR DESCRIPTION
Fixes a missing PCD define check, an image might have the network core partition layout set but if PCD support is not enabled then it should not assume that PCD support is part of mcuboot.