### PR TITLE
[nrf noup] treewide: Fix old Nordic license ID

### DIFF
--- a/boot/zephyr/boards/nrf5340dk_nrf5340_cpuapp_minimal.conf
+++ b/boot/zephyr/boards/nrf5340dk_nrf5340_cpuapp_minimal.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 # CC3xx is currently not used for nrf53

--- a/boot/zephyr/external_crypto.conf
+++ b/boot/zephyr/external_crypto.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 # These configurations should be used when using nrf/samples/bootloader

--- a/boot/zephyr/include/nrf_cleanup.h
+++ b/boot/zephyr/include/nrf_cleanup.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #ifndef H_NRF_CLEANUP_

--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include <hal/nrf_clock.h>

--- a/boot/zephyr/prj_minimal.conf
+++ b/boot/zephyr/prj_minimal.conf
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2021 Nordic Semiconductor ASA
 #
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 CONFIG_MAIN_STACK_SIZE=10240


### PR DESCRIPTION
NCS has switch to the new license ID some time ago from LicenseRef-BSD-5-Clause-Nordic to new (more
accurate) LicenseRef-Nordic-5-Clause. All source files must be adjusted to the new name.

Ref: NCSIDB-717