### PR TITLE
Support encrypted firmware signature key.

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -310,6 +310,7 @@ if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
     ${KEY_FILE}
     > ${GENERATED_PUBKEY}
     DEPENDS ${KEY_FILE}
+    USES_TERMINAL
     )
   zephyr_library_sources(${GENERATED_PUBKEY})
 endif()


### PR DESCRIPTION
When the firmware signature key is encrypted with a passphrase, imgtool.py asks the user to enter the passphrase several times during the build process.

Currently, this only works with "Unix Makefiles". With "Ninja", which is the default CMake generator in Zephyr, the build blocks without any prompt to enter the passphrase.

This patch adds the option USES_TERMINAL to several calls of add_custom_command(). Together with my pull request in repository sdk-nrf it allows to use encrypted firmware signature keys with default Ninja builds.
