### PR TITLE
fix: boot_set_confirmed_multi() ignores set/confirm command if "unset"

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -618,8 +618,8 @@ boot_set_confirmed_multi(int image_index)
         break;
 
     case BOOT_MAGIC_UNSET:
-        /* Already confirmed. */
-        goto done;
+        /* Confirm needed; proceed. */
+        break;
 
     case BOOT_MAGIC_BAD:
         /* Unexpected state. */


### PR DESCRIPTION
allow boot_set_confirmed_multi() to set mcuboot magic if "unset"

background info:
The use-case is I want to set the confirm flag in the local firmware after certain conditions have been met.
On every boot up I check the boot_is_img_confirmed() and if false, firmware does certain checks and then sets the flag using boot_write_img_confirmed().
However it seems like the flag is not being set . I dug deeper and found:

boot_is_img_confirmed() only returns true if flag value is set to BOOT_FLAG_SET
boot_write_img_confirmed() however **skips setting the flag is it is set to "UNSET"**
This PR is to change the behavior of boot_write_img_confirmed() to set the flag in the case that it is unset.

I may be missing something in the API/usage, but this was my only way to initiate the conversation as creating issues are closed/restricted.