### PR TITLE
[nrf noup] zephyr: Clean up non-secure RAM if enabled

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -360,7 +360,7 @@ zephyr_library_sources(
 )
 endif()
 
-if(CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL)
+if(CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL OR CONFIG_MCUBOOT_CLEANUP_NONSECURE_RAM)
 zephyr_library_sources(
   ${BOOT_DIR}/zephyr/nrf_cleanup.c
 )

--- a/boot/zephyr/include/nrf_cleanup.h
+++ b/boot/zephyr/include/nrf_cleanup.h
@@ -16,4 +16,9 @@
  */
 void nrf_cleanup_peripheral(void);
 
+/**
+ * Perform cleanup of non-secure RAM that may have been used by MCUBoot.
+ */
+void nrf_cleanup_ns_ram(void);
+
 #endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -115,7 +115,7 @@ K_SEM_DEFINE(boot_log_sem, 1, 1);
 #include <pm_config.h>
 #endif
 
-#if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL
+#if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL || CONFIG_MCUBOOT_NRF_CLEANUP_NONSECURE_RAM
 #include <nrf_cleanup.h>
 #endif
 
@@ -227,6 +227,9 @@ static void do_boot(struct boot_rsp *rsp)
 #endif
 #if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL
     nrf_cleanup_peripheral();
+#endif
+#if CONFIG_MCUBOOT_NRF_CLEANUP_NONSECURE_RAM && defined(PM_SRAM_NONSECURE_NAME)
+    nrf_cleanup_ns_ram();
 #endif
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
     cleanup_arm_nvic(); /* cleanup NVIC registers */

--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -20,6 +20,10 @@
 
 #include <string.h>
 
+#if defined(USE_PARTITION_MANAGER)
+#include <pm_config.h>
+#endif
+
 #define NRF_UARTE_SUBSCRIBE_CONF_OFFS offsetof(NRF_UARTE_Type, SUBSCRIBE_STARTRX)
 #define NRF_UARTE_SUBSCRIBE_CONF_SIZE (offsetof(NRF_UARTE_Type, EVENTS_CTS) -\
                                        NRF_UARTE_SUBSCRIBE_CONF_OFFS)
@@ -81,3 +85,12 @@ void nrf_cleanup_peripheral(void)
 #endif
     nrf_cleanup_clock();
 }
+
+#if defined(USE_PARTITION_MANAGER) \
+	&& defined(CONFIG_ARM_TRUSTZONE_M) \
+	&& defined(PM_SRAM_NONSECURE_NAME)
+void nrf_cleanup_ns_ram(void)
+{
+	memset((void *) PM_SRAM_NONSECURE_ADDRESS, 0, PM_SRAM_NONSECURE_SIZE);
+}
+#endif


### PR DESCRIPTION
To ensure that MCUBoot does not leak keys or other material through memory to non-secure side we clear the memory before jumping to the next image.

Ref: SI-227