### PR TITLE
[nrf noup] loader: Fix reading reset addr to support ext flash

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -917,10 +917,9 @@ boot_validated_swap_type(struct boot_loader_state *state,
 #if defined(PM_S1_ADDRESS) || defined(CONFIG_SOC_NRF5340_CPUAPP)
     const struct flash_area *secondary_fa =
         BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT);
-    struct image_header *hdr = (struct image_header *)secondary_fa->fa_off;
-    uint32_t vtable_addr = 0;
-    uint32_t *vtable = 0;
+    struct image_header *hdr = boot_img_hdr(state, BOOT_SECONDARY_SLOT);
     uint32_t reset_addr = 0;
+    int rc = 0;
     /* Patch needed for NCS. Since image 0 (the app) and image 1 (the other
      * B1 slot S0 or S1) share the same secondary slot, we need to check
      * whether the update candidate in the secondary slot is intended for
@@ -930,16 +929,19 @@ boot_validated_swap_type(struct boot_loader_state *state,
      */
 
     if (hdr->ih_magic == IMAGE_MAGIC) {
-        vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
-        vtable = (uint32_t *)(vtable_addr);
-        reset_addr = vtable[1];
+        rc = flash_area_read(secondary_fa, hdr->ih_hdr_size +
+                             sizeof(uint32_t), &reset_addr,
+                             sizeof(reset_addr));
+        if (rc != 0) {
+            return BOOT_SWAP_TYPE_FAIL;
+        }
 #ifdef PM_S1_ADDRESS
 #ifdef PM_CPUNET_B0N_ADDRESS
         if(reset_addr < PM_CPUNET_B0N_ADDRESS)
 #endif
         {
             const struct flash_area *primary_fa;
-            int rc = flash_area_open(flash_area_id_from_multi_image_slot(
+            rc = flash_area_open(flash_area_id_from_multi_image_slot(
                         BOOT_CURR_IMG(state),
                         BOOT_PRIMARY_SLOT),
                     &primary_fa);
@@ -975,16 +977,19 @@ boot_validated_swap_type(struct boot_loader_state *state,
             upgrade_valid = true;
         }
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS)
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS) \
+    && !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE)
         /* If the update is valid, and it targets the network core: perform the
          * update and indicate to the caller of this function that no update is
          * available
          */
         if (upgrade_valid && reset_addr > PM_CPUNET_B0N_ADDRESS) {
+            struct image_header *hdr = (struct image_header *)secondary_fa->fa_off;
+            uint32_t vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
+            uint32_t *net_core_fw_addr = (uint32_t *)(vtable_addr);
             uint32_t fw_size = hdr->ih_img_size;
-
             BOOT_LOG_INF("Starting network core update");
-            int rc = pcd_network_core_update(vtable, fw_size);
+            rc = pcd_network_core_update(net_core_fw_addr, fw_size);
 
             if (rc != 0) {
                 swap_type = BOOT_SWAP_TYPE_FAIL;


### PR DESCRIPTION
When mcuboot_secondary is on external flash, the image header cannot dircetly be accessed via secondary_fa->fa_off. Instead the provided function boot_img_hdr() is used now.
Additionally a similar issue is present when trying to read the address of the reset handler. For this flash_area_read() is used now.

With this patch is possible to have the update partiton mcuboot_secondary on external flash and update a updatable bootloader (mcuboot) in s0 and/or s1.

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>
Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>