### PR TITLE
[nrf fromtree] boot: zephyr: Only call sys_clock_disable when supported

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -207,7 +207,9 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_hdr->ih_hdr_size);
 #endif
 
-    sys_clock_disable();
+    if (IS_ENABLED(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT)) {
+        sys_clock_disable();
+    }
 
 #ifdef CONFIG_USB_DEVICE_STACK
     /* Disable the USB to prevent it from firing interrupts */


### PR DESCRIPTION
Only call sys_clock_disable when the system clock driver support this feature.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit 90b8f69040e604254daa7ffe58dd9add985b468a)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Bringing the commit will not hurt us and will allow auto-upmerge to got through, as it currently fails when not finding ` sys_clock_disable `