### PR TITLE
[nrf fromtree] bootutil: Fixing memset not beeing called

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1046,6 +1046,21 @@ boot_erase_region(const struct flash_area *fap, uint32_t off, uint32_t sz)
 }
 
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
+
+#if defined(MCUBOOT_ENC_IMAGES) || defined(MCUBOOT_SWAP_SAVE_ENCTLV)
+/* Replacement for memset(p, 0, sizeof(*p) that does not get
+ * optimized out.
+ */
+static void like_mbedtls_zeroize(void *p, size_t n)
+{
+    volatile unsigned char *v = (unsigned char *)p;
+
+    for (size_t i = 0; i < n; i++) {
+        v[i] = 0;
+    }
+}
+#endif
+
 /**
  * Copies the contents of one flash region to another.  You must erase the
  * destination region prior to calling this function.
@@ -2363,17 +2378,22 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
     if(FIH_NOT_EQ(fih_cnt, BOOT_IMAGE_NUMBER)) {
         FIH_PANIC;
     }
-    /*
-     * Since the boot_status struct stores plaintext encryption keys, reset
-     * them here to avoid the possibility of jumping into an image that could
-     * easily recover them.
-     */
-    memset(&bs, 0, sizeof(struct boot_status));
 
     fill_rsp(state, rsp);
 
     fih_rc = FIH_SUCCESS;
 out:
+    /*
+     * Since the boot_status struct stores plaintext encryption keys, reset
+     * them here to avoid the possibility of jumping into an image that could
+     * easily recover them.
+     */
+#if defined(MCUBOOT_ENC_IMAGES) || defined(MCUBOOT_SWAP_SAVE_ENCTLV)
+    like_mbedtls_zeroize(&bs, sizeof(bs));
+#else
+    memset(&bs, 0, sizeof(struct boot_status));
+#endif
+
     close_all_flash_areas(state);
     FIH_RET(fih_rc);
 }


### PR DESCRIPTION
Memset could have been out optimized by compiler and also not called in error path.

(cherry picked from commit 256bc37aad8f44b9971772a8e48bebf046e47e56)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>