### PR TITLE
[nrf noup] booutil: loader: Add support for NSIB and multi-image

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -838,6 +838,11 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
         if (BOOT_CURR_IMG(state) == 1) {
             min_addr = PM_CPUNET_APP_ADDRESS;
             max_addr = PM_CPUNET_APP_ADDRESS + PM_CPUNET_APP_SIZE;
+#ifdef PM_S1_ADDRESS
+        } else if (BOOT_CURR_IMG(state) == 0) {
+            min_addr = PM_S0_ADDRESS;
+            max_addr = pri_fa->fa_off + pri_fa->fa_size;
+#endif
         } else
 #endif
         {
@@ -956,20 +961,33 @@ boot_validated_swap_type(struct boot_loader_state *state,
         if(reset_addr < PM_CPUNET_B0N_ADDRESS)
 #endif
         {
+            const struct flash_area *nsib_fa;
             const struct flash_area *primary_fa;
             rc = flash_area_open(flash_area_id_from_multi_image_slot(
-                        BOOT_CURR_IMG(state),
-                        BOOT_PRIMARY_SLOT),
-                    &primary_fa);
-
+                                 BOOT_CURR_IMG(state), BOOT_PRIMARY_SLOT),
+                                 &primary_fa);
             if (rc != 0) {
                 return BOOT_SWAP_TYPE_FAIL;
             }
-            /* Get start and end of primary slot for current image */
-            if (reset_addr < primary_fa->fa_off ||
-                    reset_addr > (primary_fa->fa_off + primary_fa->fa_size)) {
-                /* The image in the secondary slot is not intended for this image
-                */
+
+            /* Check start and end of primary slot for current image */
+            if (reset_addr < primary_fa->fa_off) {
+                    /* NSIB upgrade slot */
+                    rc = flash_area_open((uint32_t)_image_1_primary_slot_id,
+                                    &nsib_fa);
+
+                    if (rc != 0) {
+                            return BOOT_SWAP_TYPE_FAIL;
+                    }
+
+                    /* Image is placed before Primary and within the NSIB slot */
+                    if (reset_addr > nsib_fa->fa_off
+                        && reset_addr < (nsib_fa->fa_off + nsib_fa->fa_size)) {
+                        /* Set primary to be NSIB upgrade slot */
+                        BOOT_IMG_AREA(state, 0) = nsib_fa;
+                    }
+            } else if (reset_addr > (primary_fa->fa_off + primary_fa->fa_size)) {
+                /* The image in the secondary slot is not intended for any */
                 return BOOT_SWAP_TYPE_NONE;
             }
         }
@@ -1232,7 +1250,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 
     image_index = BOOT_CURR_IMG(state);
 
-    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(image_index),
+    rc = flash_area_open(flash_area_get_id(BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT)),
             &fap_primary_slot);
     assert (rc == 0);
 

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -19,9 +19,24 @@
 /* If B0 is present then two bootloaders are present, and we must use
  * a single secondary slot for both primary slots.
  */
-#ifdef PM_B0_ADDRESS
-
+#if defined(PM_B0_ADDRESS)
 extern uint32_t _image_1_primary_slot_id[];
+#endif
+#if defined(PM_B0_ADDRESS) && defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE)
+#define FLASH_AREA_IMAGE_PRIMARY(x)          \
+        ((x == 0) ?                          \
+           PM_MCUBOOT_PRIMARY_ID :           \
+         (x == 1) ?                          \
+           PM_MCUBOOT_PRIMARY_1_ID :         \
+           255 )
+
+#define FLASH_AREA_IMAGE_SECONDARY(x)        \
+        ((x == 0) ?                          \
+           PM_MCUBOOT_SECONDARY_ID:          \
+        (x == 1) ?                           \
+           PM_MCUBOOT_SECONDARY_1_ID:        \
+           255 )
+#elif defined(PM_B0_ADDRESS)
 
 #define FLASH_AREA_IMAGE_PRIMARY(x)            \
         ((x == 0) ?                            \


### PR DESCRIPTION
This adds support for using both NSIB and the multi-image configuration
in MCUboot. Before, this was not possible due to the upgradable bootloader
support through NSIB was using the `UPDATEABLE_IMAGE_NUMBER`
configuration to update the updateable bootloader.

In this commit, we change from using `FLASH_AREA_IMAGE_PRIMARY` to get
the flash area ID to using the bootloader state where we set the flash
area ID of the free updatable bootloader slot if the image is intended
for this slot.

Ref. NCSDK-19223