### PR TITLE
[nrf noup] bootloader: mcuboot: Fix wrong use of if defined

### DIFF
--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -20,7 +20,7 @@
 
 #include <string.h>
 
-#if defined(USE_PARTITION_MANAGER)
+#if USE_PARTITION_MANAGER
 #include <pm_config.h>
 #endif
 
@@ -86,7 +86,7 @@ void nrf_cleanup_peripheral(void)
     nrf_cleanup_clock();
 }
 
-#if defined(USE_PARTITION_MANAGER) \
+#if USE_PARTITION_MANAGER \
 	&& defined(CONFIG_ARM_TRUSTZONE_M) \
 	&& defined(PM_SRAM_NONSECURE_NAME)
 void nrf_cleanup_ns_ram(void)


### PR DESCRIPTION
The file nrf_cleanup.c has
#if defined(USE_PARTITION_MANAGER)
Which is true even if USE_PARTITION_MANAGER=n.
This must be changed to "#if USE_PARTITION_MANAGER" for correct behaviour.

Ref: NCSIDB-987