### PR TITLE
[nrf fromlist] bootutil: Add DirectXIP version of boot_set_next

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -295,18 +295,6 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
 #endif
 
 int
-boot_write_copy_done(const struct flash_area *fap)
-{
-    uint32_t off;
-
-    off = boot_copy_done_off(fap);
-    BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%lx (0x%lx)",
-                 flash_area_get_id(fap), (unsigned long)off,
-                 (unsigned long)(flash_area_get_off(fap) + off));
-    return boot_write_trailer_flag(fap, off, BOOT_FLAG_SET);
-}
-
-int
 boot_write_swap_size(const struct flash_area *fap, uint32_t swap_size)
 {
     uint32_t off;

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -459,6 +459,20 @@ boot_swap_type_multi(int image_index)
 }
 
 int
+boot_write_copy_done(const struct flash_area *fap)
+{
+    uint32_t off;
+
+    off = boot_copy_done_off(fap);
+    BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%lx (0x%lx)",
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)(flash_area_get_off(fap) + off));
+    return boot_write_trailer_flag(fap, off, BOOT_FLAG_SET);
+}
+
+
+#ifndef MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
+int
 boot_set_next(const struct flash_area *fa, bool active, bool confirm)
 {
     struct boot_swap_state slot_state;
@@ -528,6 +542,72 @@ boot_set_next(const struct flash_area *fa, bool active, bool confirm)
 
     return rc;
 }
+#else
+int
+boot_set_next(const struct flash_area *fa, bool active, bool confirm)
+{
+    struct boot_swap_state slot_state;
+    int rc;
+
+    if (active) {
+        /* The only way to set active slot for next boot is to confirm it,
+         * as DirectXIP will conclude that, since slot has not been confirmed
+         * last boot, it is bad and will remove it.
+         */
+        confirm = true;
+    }
+
+    rc = boot_read_swap_state(fa, &slot_state);
+    if (rc != 0) {
+        return rc;
+    }
+
+    switch (slot_state.magic) {
+    case BOOT_MAGIC_UNSET:
+        /* Magic is needed for MCUboot to even consider booting an image */
+        rc = boot_write_magic(fa);
+        if (rc != 0) {
+            break;
+        }
+        /* Pass */
+
+    case BOOT_MAGIC_GOOD:
+        if (confirm) {
+            if (slot_state.copy_done == BOOT_FLAG_UNSET) {
+                /* Magic is needed for DirectXIP to even try to boot application.
+                 * DirectXIP will set copy-done flag before attempting to boot
+                 * application. Next boot, application that has copy-done flag
+                 * is expected to already have ok flag, otherwise it will be removed.
+                 */
+                rc = boot_write_copy_done(fa);
+                if (rc != 0) {
+                    break;
+                }
+            }
+
+            if (slot_state.image_ok == BOOT_FLAG_UNSET) {
+                rc = boot_write_image_ok(fa);
+                if (rc != 0) {
+                    break;
+                }
+            }
+        }
+        break;
+
+    case BOOT_MAGIC_BAD:
+        /* This image will not be boot next time anyway */
+        rc = BOOT_EBADIMAGE;
+        break;
+
+    default:
+        /* Something is not OK, this should never happen */
+        assert(0);
+        rc = BOOT_EBADSTATUS;
+    }
+
+    return rc;
+}
+#endif
 
 /*
  * This function is not used by the bootloader itself, but its required API

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 Open Source Foundries Limited
  * Copyright (c) 2019-2020 Arm Limited
  * Copyright (c) 2019-2020 Linaro Limited
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -266,6 +267,10 @@
         #define MCUBOOT_BOOT_MAX_ALIGN \
             DT_PROP(DT_CHOSEN(zephyr_flash), write_block_size)
     #endif
+#endif
+
+#ifdef CONFIG_MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
+#define MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP 1
 #endif
 
 #if CONFIG_BOOT_WATCHDOG_FEED


### PR DESCRIPTION
The commit adds DirectXIP version of bootutil boot_set_next function.
The function is enabled by configuration option:
MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP.

Upstream PR: https://github.com/mcu-tools/mcuboot/pull/1676