### PR TITLE
Series of important fixes from mcu-tools/mcuboot/main

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -295,18 +295,6 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
 #endif
 
 int
-boot_write_copy_done(const struct flash_area *fap)
-{
-    uint32_t off;
-
-    off = boot_copy_done_off(fap);
-    BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%lx (0x%lx)",
-                 flash_area_get_id(fap), (unsigned long)off,
-                 (unsigned long)(flash_area_get_off(fap) + off));
-    return boot_write_trailer_flag(fap, off, BOOT_FLAG_SET);
-}
-
-int
 boot_write_swap_size(const struct flash_area *fap, uint32_t swap_size)
 {
     uint32_t off;

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -472,10 +472,11 @@ boot_write_copy_done(const struct flash_area *fap)
 
 #ifndef MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
 
-static int flash_area_id_to_image(int id)
+static int flash_area_to_image(const struct flash_area *fa)
 {
 #if BOOT_IMAGE_NUMBER > 1
     uint8_t i = 0;
+    int id = flash_area_get_id(fa);
 
     while (i < BOOT_IMAGE_NUMBER) {
         if (FLASH_AREA_IMAGE_PRIMARY(i) == id || (FLASH_AREA_IMAGE_SECONDARY(i) == id)) {
@@ -485,7 +486,7 @@ static int flash_area_id_to_image(int id)
         ++i;
     }
 #else
-    (void)id;
+    (void)fa;
 #endif
     return 0;
 }
@@ -535,8 +536,7 @@ boot_set_next(const struct flash_area *fa, bool active, bool confirm)
                 } else {
                     swap_type = BOOT_SWAP_TYPE_TEST;
                 }
-                rc = boot_write_swap_info(fa, swap_type,
-                                          flash_area_id_to_image(flash_area_get_id(fa)));
+                rc = boot_write_swap_info(fa, swap_type, flash_area_to_image(fa));
             }
         }
         break;

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -460,11 +460,15 @@ boot_swap_type_multi(int image_index)
 
 static int flash_area_id_to_image(int id)
 {
-#if BOOT_IMAGE_NUMBER > 2
-#error "BOOT_IMAGE_NUMBER > 2 requires change to flash_area_id_to_image"
-#elif BOOT_IMAGE_NUMBER > 1
-    if (FLASH_AREA_IMAGE_PRIMARY(1) == id || (FLASH_AREA_IMAGE_SECONDARY(1) == id)) {
-        return 1;
+#if BOOT_IMAGE_NUMBER > 1
+    uint8_t i = 0;
+
+    while (i < BOOT_IMAGE_NUMBER) {
+        if (FLASH_AREA_IMAGE_PRIMARY(i) == id || (FLASH_AREA_IMAGE_SECONDARY(i) == id)) {
+            return i;
+        }
+
+        ++i;
     }
 #else
     (void)id;

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -463,7 +463,7 @@ static int flash_area_id_to_image(int id)
 #if BOOT_IMAGE_NUMBER > 2
 #error "BOOT_IMAGE_NUMBER > 2 requires change to flash_area_id_to_image"
 #elif BOOT_IMAGE_NUMBER > 1
-    if (FLASH_AREA_IMAGE_SECONDARY(0) == id || (FLASH_AREA_IMAGE_SECONDARY(1) == id)) {
+    if (FLASH_AREA_IMAGE_PRIMARY(1) == id || (FLASH_AREA_IMAGE_SECONDARY(1) == id)) {
         return 1;
     }
 #else

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -458,6 +458,20 @@ boot_swap_type_multi(int image_index)
     return BOOT_SWAP_TYPE_NONE;
 }
 
+static int flash_area_id_to_image(int id)
+{
+#if BOOT_IMAGE_NUMBER > 2
+#error "BOOT_IMAGE_NUMBER > 2 requires change to flash_area_id_to_image"
+#elif BOOT_IMAGE_NUMBER > 1
+    if (FLASH_AREA_IMAGE_SECONDARY(0) == id || (FLASH_AREA_IMAGE_SECONDARY(1) == id)) {
+        return 1;
+    }
+#else
+    (void)id;
+#endif
+    return 0;
+}
+
 int
 boot_set_next(const struct flash_area *fa, bool active, bool confirm)
 {
@@ -503,7 +517,8 @@ boot_set_next(const struct flash_area *fa, bool active, bool confirm)
                 } else {
                     swap_type = BOOT_SWAP_TYPE_TEST;
                 }
-                rc = boot_write_swap_info(fa, swap_type, 0);
+                rc = boot_write_swap_info(fa, swap_type,
+                                          flash_area_id_to_image(flash_area_get_id(fa)));
             }
         }
         break;

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -458,6 +458,20 @@ boot_swap_type_multi(int image_index)
     return BOOT_SWAP_TYPE_NONE;
 }
 
+int
+boot_write_copy_done(const struct flash_area *fap)
+{
+    uint32_t off;
+
+    off = boot_copy_done_off(fap);
+    BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%lx (0x%lx)",
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)(flash_area_get_off(fap) + off));
+    return boot_write_trailer_flag(fap, off, BOOT_FLAG_SET);
+}
+
+#ifndef MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
+
 static int flash_area_id_to_image(int id)
 {
 #if BOOT_IMAGE_NUMBER > 1
@@ -476,20 +490,6 @@ static int flash_area_id_to_image(int id)
     return 0;
 }
 
-int
-boot_write_copy_done(const struct flash_area *fap)
-{
-    uint32_t off;
-
-    off = boot_copy_done_off(fap);
-    BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%lx (0x%lx)",
-                 flash_area_get_id(fap), (unsigned long)off,
-                 (unsigned long)(flash_area_get_off(fap) + off));
-    return boot_write_trailer_flag(fap, off, BOOT_FLAG_SET);
-}
-
-
-#ifndef MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
 int
 boot_set_next(const struct flash_area *fa, bool active, bool confirm)
 {

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018 Open Source Foundries Limited
  * Copyright (c) 2019-2020 Arm Limited
  * Copyright (c) 2019-2020 Linaro Limited
+ * Copyright (c) 2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -266,6 +267,10 @@
         #define MCUBOOT_BOOT_MAX_ALIGN \
             DT_PROP(DT_CHOSEN(zephyr_flash), write_block_size)
     #endif
+#endif
+
+#ifdef CONFIG_MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
+#define MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP 1
 #endif
 
 #if CONFIG_BOOT_WATCHDOG_FEED


### PR DESCRIPTION
1) Fix for boot_set_next passing incorrect image number.
2) Fix for flash_area_id_to_image incorrectly recognizing image number.
3) Switch to flash_area_to_image which is replacement for flash_area_id_to_image.

... and several more.