### PR TITLE
[nrf fromtree] zephyr: Provide third image cases for direct image upload

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -110,6 +110,14 @@ int flash_area_id_from_direct_image(int image_id)
     case 4:
         return FIXED_PARTITION_ID(slot3_partition);
 #endif
+#if FIXED_PARTITION_EXISTS(slot4_partition)
+    case 5:
+        return FIXED_PARTITION_ID(slot4_partition);
+#endif
+#if FIXED_PARTITION_EXISTS(slot5_partition)
+    case 6:
+        return FIXED_PARTITION_ID(slot5_partition);
+#endif
     }
     return -EINVAL;
 }


### PR DESCRIPTION
The commit adds missing support for direct upload of third image slots.

(cherry picked from commit 0035c33b447c77233895ae0a8f0d93b83be78ac1)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>