### PR TITLE
sysflash: pm_sysflash: Fix incorrect include of NSIB image define

### DIFF
--- a/boot/zephyr/include/sysflash/pm_sysflash.h
+++ b/boot/zephyr/include/sysflash/pm_sysflash.h
@@ -15,13 +15,15 @@
 
 #ifndef CONFIG_SINGLE_APPLICATION_SLOT
 
-#if (MCUBOOT_IMAGE_NUMBER == 2) && defined(PM_B0_ADDRESS) && \
-      !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE)
-
+#if (MCUBOOT_IMAGE_NUMBER == 2) && defined(PM_B0_ADDRESS)
 /* If B0 is present then two bootloaders are present, and we must use
  * a single secondary slot for both primary slots.
  */
 extern uint32_t _image_1_primary_slot_id[];
+#endif /* (MCUBOOT_IMAGE_NUMBER == 2 && defined(PM_B0_ADDRESS) */
+
+#if (MCUBOOT_IMAGE_NUMBER == 2) && defined(PM_B0_ADDRESS) && \
+      !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE)
 
 #define FLASH_AREA_IMAGE_PRIMARY(x)             \
         ((x == 0) ?                             \


### PR DESCRIPTION
A mismatch in defines was made for `_image_1_primary_slot_id` resulting in some configurations not working. This fixes that the linker variable is exposed for mcuboot so that it knows which slot is running an which slot a bootloader upgrade is to be put into.

Ref. NCSDK-19223