### PR TITLE
Revert "[nrf noup] boot: zephyr: Enable zeroize ALT func"

### DIFF
--- a/boot/zephyr/include/mcuboot-mbedtls-cfg.h
+++ b/boot/zephyr/include/mcuboot-mbedtls-cfg.h
@@ -21,16 +21,6 @@
  * the simulator build.rs accordingly.
  */
 
-/*
- * When the CC3XX_PLATFORM library is enabled we need to
- * inform the Mbed TLS library to not compile the
- * platform_zeroize function, otherwise we will get
- * a multiple definitions error.
- */
-#if defined(CONFIG_NRF_CC3XX_PLATFORM)
-#define MBEDTLS_PLATFORM_ZEROIZE_ALT
-#endif
-
 #if defined(CONFIG_BOOT_SIGNATURE_TYPE_RSA) || defined(CONFIG_BOOT_ENCRYPT_RSA)
 #include "config-rsa.h"
 #elif defined(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256) || \


### PR DESCRIPTION
The mbedtls platform zeorize function is not provided by the CryptoCell anymore so it is not needed.
This reverts commit 4c1d75f4ac410eb1c365db873bb4be41cc9329c5.