### PR TITLE
[nrf fromtree] boot: Fix swap-move algorithm failing to validate mult…

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2016-2020 Linaro LTD
  * Copyright (c) 2016-2019 JUUL Labs
  * Copyright (c) 2019-2023 Arm Limited
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * Original license:
  *
@@ -2372,8 +2373,13 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
         if (BOOT_SWAP_TYPE(state) != BOOT_SWAP_TYPE_NONE) {
             /* Attempt to read an image header from each slot. Ensure that image
              * headers in slots are aligned with headers in boot_data.
+	     * Note: Quite complicated internal logic of boot_read_image_headers
+	     * uses boot state, the last parm, to figure out in which slot which
+	     * header is located; when boot state is not provided, then it
+	     * is assumed that headers are at proper slots (we are not in
+	     * the middle of moving images, etc).
              */
-            rc = boot_read_image_headers(state, false, &bs);
+            rc = boot_read_image_headers(state, false, NULL);
             if (rc != 0) {
                 FIH_SET(fih_rc, FIH_FAILURE);
                 goto out;


### PR DESCRIPTION
…i-image

In multi image swap validation of images could fail due to headers being incorrectly re-read from storage.

Fixes #1768

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
(cherry picked from commit 6f7f87384da1e701700b2f436fc49441f693a346)