### PR TITLE
boot/zephyr/nrf_cleanup: cleanup uarte pins

### DIFF
--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -7,6 +7,7 @@
 #include <hal/nrf_clock.h>
 #include <hal/nrf_uarte.h>
 #include <haly/nrfy_uarte.h>
+#include <haly/nrfy_gpio.h>
 #if defined(NRF_RTC0) || defined(NRF_RTC1) || defined(NRF_RTC2)
     #include <hal/nrf_rtc.h>
 #endif
@@ -91,6 +92,21 @@ void nrf_cleanup_peripheral(void)
         nrfy_uarte_event_clear(current, NRF_UARTE_EVENT_ENDRX);
         nrfy_uarte_event_clear(current, NRF_UARTE_EVENT_RXTO);
         nrfy_uarte_disable(current);
+
+        uint32_t pin[4];
+
+        pin[0] = nrfy_uarte_tx_pin_get(current);
+        pin[1] = nrfy_uarte_rx_pin_get(current);
+        pin[2] = nrfy_uarte_rts_pin_get(current);
+        pin[3] = nrfy_uarte_cts_pin_get(current);
+
+        nrfy_uarte_pins_disconnect(current);
+
+        for (int j = 0; j < 4; j++) {
+            if (pin[j] != NRF_UARTE_PSEL_DISCONNECTED) {
+                nrfy_gpio_cfg_default(pin[i]);
+            }
+        }
 
 #if defined(NRF_DPPIC)
         /* Clear all SUBSCRIBE configurations. */


### PR DESCRIPTION
Added procedure which does configure UARTE pins to the default states. This allows to reduce power consumption if pin is floating.

Ref.: NCSIDB-1194