### PR TITLE
[nrf noup] zephyr/boards: fix nrf54l15pdk ext flash dts overlay

### DIFF
--- a/boot/zephyr/boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay
+++ b/boot/zephyr/boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay
@@ -14,7 +14,8 @@
 
 /delete-node/ &storage_partition;
 
-&rram0 {
+&cpuapp_rram {
+	reg = < 0x0 DT_SIZE_K(1524) >;
 	partitions {
 		boot_partition: partition@0 {
 			label = "mcuboot";


### PR DESCRIPTION
Align to changes in DTS:
renamed: rram0 -> cpuapp_rram
sized up cpauapp_rram region szie as part of it was reserwed for cpuflpr_rram (which is not used by this config).