### PR TITLE
boot: zephyr: boards: nrf54l15pdk BOOT_MAX_IMG_SECTORS

### DIFF
--- a/boot/zephyr/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/boot/zephyr/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-CONFIG_BOOT_MAX_IMG_SECTORS=256
+CONFIG_BOOT_MAX_IMG_SECTORS=768
 
 # Ensure that the qspi driver is disabled by default
 CONFIG_NORDIC_QSPI_NOR=n


### PR DESCRIPTION
adjusting BOOT_MAX_IMG_SECTORS to match 1K blocks.