### PR TITLE
[nrf noup] boot: zephyr: Do not lock PCD region with TF-M

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -608,7 +608,11 @@ int main(void)
     }
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS) && defined(CONFIG_PCD_APP)
-    pcd_lock_ram();
+#if defined(PM_TFM_SECURE_ADDRESS)
+    pcd_lock_ram(false);
+#else
+    pcd_lock_ram(true);
+#endif
 #endif
 #endif /* USE_PARTITION_MANAGER && CONFIG_FPROTECT */
 


### PR DESCRIPTION
Previously PCD memory was locked as read-only, non-secure in MCUboot. Given that TF-M also needs write to PCD to communicate with b0n, the memory is left unlocked and locked to read-only, non-secure in TF-M.
