### PR TITLE
ED25519 KMU

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -245,6 +245,7 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
 #   define KEY_BUF_SIZE         (SIG_BUF_SIZE + 24)
 #endif /* !MCUBOOT_HW_KEY */
 
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
 #if !defined(MCUBOOT_HW_KEY)
 static int
 bootutil_find_key(uint8_t *keyhash, uint8_t keyhash_len)
@@ -310,6 +311,7 @@ bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
 }
 #endif /* !MCUBOOT_HW_KEY */
 #endif /* !MCUBOOT_BUILTIN_KEY */
+#endif /* !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) */
 #endif /* EXPECTED_SIG_TLV */
 
 /**
@@ -626,6 +628,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
             break;
         }
 #endif /* defined(EXPECTED_HASH_TLV) && !defined(MCUBOOT_SIGN_PURE) */
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
 #ifdef EXPECTED_KEY_TLV
         case EXPECTED_KEY_TLV:
         {
@@ -656,14 +659,17 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
             break;
         }
 #endif /* EXPECTED_KEY_TLV */
+#endif /* !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) */
 #ifdef EXPECTED_SIG_TLV
         case EXPECTED_SIG_TLV:
         {
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
             /* Ignore this signature if it is out of bounds. */
             if (key_id < 0 || key_id >= bootutil_key_cnt) {
                 key_id = -1;
                 continue;
             }
+#endif /* !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) */
             if (!EXPECTED_SIG_LEN(len) || len > sizeof(buf)) {
                 rc = -1;
                 goto out;

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -297,7 +297,7 @@ if(CONFIG_MCUBOOT_SERIAL)
   endif()
 endif()
 
-if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
+if(NOT CONFIG_BOOT_SIGNATURE_USING_KMU OR NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
   # CONF_FILE points to the KConfig configuration files of the bootloader.
   foreach (filepath ${CONF_FILE})
     file(READ ${filepath} temp_text)

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -194,6 +194,7 @@ endchoice # BOOT_IMG_HASH_ALG
 
 config BOOT_SIGNATURE_TYPE_PURE_ALLOW
 	bool
+	depends on NRF_SECURITY
 	help
 	  Hidden option set by configurations that allow Pure variant,
 	  for example ed25519. The pure variant means that image
@@ -293,6 +294,7 @@ config BOOT_ED25519_MBEDTLS
 
 config BOOT_ED25519_PSA
 	bool "Use PSA crypto"
+	depends on NRF_SECURITY
 	select BOOT_USE_PSA_CRYPTO
 	select BOOT_ED25519_PSA_DEPENDENCIES
 	select BOOT_X25519_PSA_DEPENDENCIES if BOOT_ENCRYPT_IMAGE
@@ -301,6 +303,22 @@ endchoice
 endif
 
 endchoice
+
+config BOOT_SIGNATURE_USING_KMU
+	bool "Use KMU stored keys for signature verification"
+	depends on NRF_SECURITY
+	depends on CRACEN_LIB_KMU
+	select PSA_WANT_ALG_GCM
+	select PSA_WANT_KEY_TYPE_AES
+	select PSA_WANT_AES_KEY_SIZE_256
+	select PSA_WANT_ALG_SP800_108_COUNTER_CMAC
+	select PSA_WANT_ALG_CMAC
+	select PSA_WANT_ALG_ECB_NO_PADDING
+	help
+	  MCUboot will use keys provisioned to the device key management unit for signature
+	  verification instead of compiling in key data from a file.
+
+if !BOOT_SIGNATURE_USING_KMU
 
 config BOOT_SIGNATURE_KEY_FILE
 	string "PEM key file"
@@ -319,6 +337,8 @@ config BOOT_SIGNATURE_KEY_FILE
 	  with the public key information will be written in a format expected by
 	  MCUboot.
 
+endif
+
 config MCUBOOT_CLEANUP_ARM_CORE
 	bool "Perform core cleanup before chain-load the application"
 	depends on CPU_CORTEX_M
@@ -335,10 +355,18 @@ config MCUBOOT_CLEANUP_ARM_CORE
 	  start-up code which can cause a module fault and potentially make the
 	  module irrecoverable.
 
+# Disable MBEDTLS from being selected if NRF_SECURITY is enabled, and use default NRF_SECURITY
+# configuration file for MBEDTLS
+config MBEDTLS
+	depends on !NRF_SECURITY
+
+config NRF_SECURITY
+	select MBEDTLS_PROMPTLESS
+
 if MBEDTLS
 
 config MBEDTLS_CFG_FILE
-	default "mcuboot-mbedtls-cfg.h"
+	default "mcuboot-mbedtls-cfg.h" if !NRF_SECURITY
 
 endif
 


### PR DESCRIPTION
KMU support, where image signature is verified using KMU provisioned keys.

- [x] requires https://github.com/nrfconnect/sdk-nrf/pull/17973

To test:

In order to make building possible: Need to include https://github.com/nrfconnect/sdk-mcuboot/pull/352 :
``` diff
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -1,7 +1,6 @@
 CONFIG_PM=n
 
 CONFIG_MAIN_STACK_SIZE=10240
-CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 
 CONFIG_BOOT_SWAP_SAVE_ENCTLV=n
 CONFIG_BOOT_ENCRYPT_IMAGE=n
```

``` console
west build  -p -d builds/hello_54_sb_ed_psa_kmu2 -b nrf54l15dk/nrf54l15/cpuapp zephyr/samples/hello_world/ -DSB_CONFIG_BOOTLOADER_MCUBOOT=y -DSB_CONFIG_BOOT_SIGNATURE_TYPE_ED25519=y -Dmcuboot_CONFIG_NRF_SECURITY=y -Dmcuboot_CONFIG_MBEDTLS=n -Dmcuboot_CONFIG_BOOT_ED25519_PSA=y -Dmcuboot_CONFIG_PM_PARTITION_SIZE_MCUBOOT=0x10000 -Dmcuboot_CONFIG_BOOT_SIGNATURE_USING_KMU=y
```

Console output should looks like:
``` console
I: Starting bootloader
I: Primary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Secondary image: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
I: Boot source: none
I: Image index: 0, Swap type: none
E: ED25519 signature verification failed -136
E: ED25519 signature verification failed -133
I: Bootloader chainload address offset: 0x10000
I: Jumping to the first image slot
*** Booting nRF Connect SDK v2.7.99-3d0a30462cc2 ***
*** Using Zephyr OS v3.7.99-6ccfcdc1051d ***
Hello World! nrf54l15dk/nrf54l15/cpuapp
```

