### PR TITLE
Fixups of typos and unneded sha checks

### DIFF
--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -118,7 +118,7 @@ bootutil_verify_img(const uint8_t *img, uint32_t size,
     uint8_t *pubkey;
     uint8_t *end;
 
-    if (slen != EDDSA_SIGNAGURE_LENGTH) {
+    if (slen != EDDSA_SIGNATURE_LENGTH) {
         FIH_SET(fih_rc, FIH_FAILURE);
         goto out;
     }

--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -22,16 +22,15 @@
 
 #include "bootutil_priv.h"
 #include "bootutil/crypto/common.h"
+#include "bootutil/crypto/sha.h"
 
-#define SHA512_LEN      64
-#define SHA256_LEN      32
-#define EDDSA_SIGNAGURE_LENGTH 64
+#define EDDSA_SIGNATURE_LENGTH 64
 
 static const uint8_t ed25519_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG "\x65\x70";
 #define NUM_ED25519_BYTES 32
 
 extern int ED25519_verify(const uint8_t *message, size_t message_len,
-                          const uint8_t signature[EDDSA_SIGNAGURE_LENGTH],
+                          const uint8_t signature[EDDSA_SIGNATURE_LENGTH],
                           const uint8_t public_key[NUM_ED25519_BYTES]);
 
 /*
@@ -82,8 +81,7 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     uint8_t *pubkey;
     uint8_t *end;
 
-    if (!(hlen == SHA512_LEN || hlen == SHA256_LEN) ||
-        slen != EDDSA_SIGNAGURE_LENGTH) {
+    if (hlen != IMAGE_HASH_SIZE || slen != EDDSA_SIGNATURE_LENGTH) {
         FIH_SET(fih_rc, FIH_FAILURE);
         goto out;
     }
@@ -97,7 +95,7 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
         goto out;
     }
 
-    rc = ED25519_verify(hash, hlen, sig, pubkey);
+    rc = ED25519_verify(hash, IMAGE_HASH_SIZE, sig, pubkey);
 
     if (rc == 0) {
         /* if verify returns 0, there was an error. */


### PR DESCRIPTION
Two fixup commits that fix typo in identifier name, the code was working because I was consistent in making the same typo allover it.

And removal of unneded sha len check.