### PR TITLE
ASN.1 Decoding bypass that allows to reduce size of flash when ED25519 is used

### DIFF
--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -17,10 +17,12 @@
 #ifdef MCUBOOT_SIGN_ED25519
 #include "bootutil/sign_key.h"
 
+#if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
 /* We are not really using the MBEDTLS but need the ASN.1 parsing functions */
 #define MBEDTLS_ASN1_PARSE_C
 #include "mbedtls/oid.h"
 #include "mbedtls/asn1.h"
+#endif
 
 #include "bootutil_priv.h"
 #include "bootutil/crypto/common.h"
@@ -34,12 +36,12 @@ extern int ED25519_verify(const uint8_t *message, size_t message_len,
                           const uint8_t public_key[NUM_ED25519_BYTES]);
 
 #if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
-
-static const uint8_t ed25519_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG "\x65\x70";
-
+#if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
 /*
  * Parse the public key used for signing.
  */
+static const uint8_t ed25519_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG "\x65\x70";
+
 static int
 bootutil_import_key(uint8_t **cp, uint8_t *end)
 {
@@ -97,11 +99,24 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     pubkey = (uint8_t *)bootutil_keys[key_id].key;
     end = pubkey + *bootutil_keys[key_id].len;
 
+#if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
     rc = bootutil_import_key(&pubkey, end);
     if (rc) {
         FIH_SET(fih_rc, FIH_FAILURE);
         goto out;
     }
+#else
+    /* Directly use the key contents from the ASN stream,
+     * these are the last NUM_ED25519_BYTES.
+     * There is no check whether this is the correct key,
+     * here, by the algorithm selected.
+     */
+    if (*bootutil_keys[key_id].len < NUM_ED25519_BYTES) {
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
+    }
+
+    pubkey = end - NUM_ED25519_BYTES;
 #endif
 
     rc = ED25519_verify(hash, IMAGE_HASH_SIZE, sig, pubkey);

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -299,6 +299,15 @@ config BOOT_ED25519_PSA
 	select BOOT_X25519_PSA_DEPENDENCIES if BOOT_ENCRYPT_IMAGE
 
 endchoice
+
+config BOOT_KEY_IMPORT_BYPASS_ASN
+	bool "Directly access key value without ASN.1 parsing"
+	help
+	  Originally, public keys compiled into MCUboot were
+	  stored in ASN.1 encoded format. Enabling this option
+	  bypasses the ASN.1 decoding and directly accesses the key
+	  in ASN.1 bitstream; this reduces MCUboot code by removing
+	  the ASN.1 processing.
 endif
 
 endchoice

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -34,6 +34,10 @@
 #     error "One crypto library implementation allowed at a time."
 #endif
 
+#if defined(CONFIG_BOOT_KEY_IMPORT_BYPASS_ASN)
+#define MCUBOOT_KEY_IMPORT_BYPASS_ASN
+#endif
+
 #ifdef CONFIG_BOOT_USE_MBEDTLS
 #define MCUBOOT_USE_MBED_TLS
 #elif defined(CONFIG_BOOT_USE_TINYCRYPT)


### PR DESCRIPTION
The PR adds options that allow to remove run-time ASN.1 decoding of ED25519 public key embedded in MCUboot build, which in turn reduces flash size used by MCUboot.


When building nrf52840dk Hello world:
```
west build  -b nrf52840dk/nrf52840 -d builds/sb_hello52 zephyr/samples/hello_world/ -- -DSB_CONFIG_BOOTLOADER_MUBOOT=y -DSB_CONFIG_BOOT_SIGNATURE_TYPE_ED25519=y
```

We get 41898 bytes of flash for MCUboot without bypass and 41386 when `-Dmcuboot_CONFIG_BOOT_KEY_IMPORT_BYPASS_ASN=y` is added to command line.

