### PR TITLE
Revert "[nrf fromlist] zephyr/Kconfig.serial_recovery: limit Slot inf…

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -204,8 +204,7 @@ config BOOT_SERIAL_IMG_GRP_IMAGE_STATE
 
 config BOOT_SERIAL_IMG_GRP_SLOT_INFO
 	bool "Slot info"
-	depends on !BOOT_DIRECT_XIP && !BOOT_RAM_LOAD
-	default y if (UPDATEABLE_IMAGE_NUMBER > 1)
+	default y if UPDATEABLE_IMAGE_NUMBER > 1
 	help
 	  If y, will include the slot info command which lists what available
 	  slots there are in the system.


### PR DESCRIPTION
…o command"

This reverts commit e295db1208183f0fa8ddbe4fa243014fe676bbb5.

The hoot-fix is no needed anymore as the 'Slot info' command feature was extended so its supports direct-xip and ram-load modes.