### PR TITLE
Bring in missing SIG_PURE definition to imgtool.py.

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -102,9 +102,9 @@ struct flash_area;
 #define IMAGE_TLV_ECDSA_SIG         0x22   /* ECDSA of hash output */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
 #define IMAGE_TLV_ED25519           0x24   /* ed25519 of hash output */
-#define IMAGE_TLV_SIG_PURE          0x25   /* Whatever signature has been selected, it will be used
-                                            * as "pure" where signature is verified over entire
-                                            * image rather than hash of an image */
+#define IMAGE_TLV_SIG_PURE          0x25   /* Indicator that attached signature has been prepared
+                                            * over image rather than its digest.
+                                            */
 #define IMAGE_TLV_ENC_RSA2048       0x30   /* Key encrypted with RSA-OAEP-2048 */
 #define IMAGE_TLV_ENC_KW            0x31   /* Key encrypted with AES-KW 128 or 256*/
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES-EC256 */

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -83,6 +83,7 @@ TLV_VALUES = {
         'ECDSASIG': 0x22,
         'RSA3072': 0x23,
         'ED25519': 0x24,
+        'SIG_PURE': 0x25,
         'ENCRSA2048': 0x30,
         'ENCKW': 0x31,
         'ENCEC256': 0x32,


### PR DESCRIPTION
There was one cherry-pick missing.