### PR TITLE
Set of PSA encryption fixes

### DIFF
--- a/boot/bootutil/src/encrypted_psa.c
+++ b/boot/bootutil/src/encrypted_psa.c
@@ -103,6 +103,7 @@ void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
 }
 
 #if defined(MCUBOOT_ENC_IMAGES)
+extern const struct bootutil_key bootutil_enc_key;
 /*
  * Decrypt an encryption key TLV.
  *

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -313,7 +313,7 @@ if(CONFIG_MCUBOOT_SERIAL)
   endif()
 endif()
 
-if(NOT CONFIG_BOOT_SIGNATURE_USING_KMU OR NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
+if(NOT CONFIG_BOOT_SIGNATURE_USING_KMU AND NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
   # CONF_FILE points to the KConfig configuration files of the bootloader.
   foreach (filepath ${CONF_FILE})
     file(READ ${filepath} temp_text)

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -194,7 +194,6 @@ endchoice # BOOT_IMG_HASH_ALG
 
 config BOOT_SIGNATURE_TYPE_PURE_ALLOW
 	bool
-	depends on NRF_SECURITY
 	help
 	  Hidden option set by configurations that allow Pure variant,
 	  for example ed25519. The pure variant means that image


### PR DESCRIPTION
Fixes in Kconfig, CMake and on in encryption source where one line got lost, somehow, when moving encryption to separate file.

X25519/AES encryption on nrf54l15 PSA has been retested on target and works fine

backport of #362