### PR TITLE
[nrf noup] zephyr: Fix compressed chunk size mismatch

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -962,9 +962,9 @@ menuconfig BOOT_DECOMPRESSION
 if BOOT_DECOMPRESSION
 
 config BOOT_DECOMPRESSION_BUFFER_SIZE
-	int "Write buffer size"
+	int
 	range 16 16384
-	default 4096
+	default NRF_COMPRESS_CHUNK_SIZE
 	help
 	  The size of a secondary buffer used for writing decompressed data to the storage device.
 


### PR DESCRIPTION
fixup! [nrf noup] zephyr: Add support for compressed image updates

Fixes an issue with a mismatch of the chunk size used when decompressing firmware updates