### PR TITLE
[nrf noup] boot: zephyr: Add experimental selection to compression

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -950,9 +950,10 @@ config BOOT_DECOMPRESSION_SUPPORT
 if BOOT_DECOMPRESSION_SUPPORT
 
 menuconfig BOOT_DECOMPRESSION
-	bool "Decompression"
+	bool "Decompression [EXPERIMENTAL]"
 	select NRF_COMPRESS_CLEANUP
 	select PM_USE_CONFIG_SRAM_SIZE if SOC_NRF54L15_CPUAPP
+	select EXPERIMENTAL
 	help
 	  If enabled, will include support for compressed images being loaded to the secondary slot
 	  which then get decompressed into the primary slot. This mode allows the secondary slot to


### PR DESCRIPTION
Adds selecting the experimental Kconfig when compession is in use