### PR TITLE
[nrf noup] Fix logging for ED25519_psa

### DIFF
--- a/boot/bootutil/src/ed25519_psa.c
+++ b/boot/bootutil/src/ed25519_psa.c
@@ -16,7 +16,7 @@
 #include <cracen_psa_kmu.h>
 #endif
 
-BOOT_LOG_MODULE_DECLARE(ed25519_psa);
+BOOT_LOG_MODULE_REGISTER(ed25519_psa);
 
 #define SHA512_DIGEST_LENGTH    64
 #define EDDSA_KEY_LENGTH        32


### PR DESCRIPTION
Log module has been declared but never registered. This commit fixes that by just registering the module.