### PR TITLE
[nrf noup] boot: bootutil: Allow configuring number of KMU keys

### DIFF
--- a/boot/bootutil/src/ed25519_psa.c
+++ b/boot/bootutil/src/ed25519_psa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -12,6 +12,7 @@
 
 #include <psa/crypto.h>
 #include <psa/crypto_types.h>
+#include <zephyr/sys/util.h>
 #if defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
 #include <cracen_psa_kmu.h>
 #endif
@@ -30,7 +31,9 @@ static psa_key_id_t kmu_key_ids[3] =  {
     MAKE_PSA_KMU_KEY_ID(228),
     MAKE_PSA_KMU_KEY_ID(230)
 };
-#define KMU_KEY_COUNT (sizeof(kmu_key_ids)/sizeof(kmu_key_ids[0]))
+
+BUILD_ASSERT(CONFIG_BOOT_SIGNATURE_KMU_SLOTS <= ARRAY_SIZE(kmu_key_ids),
+	     "Invalid number of KMU slots, up to 3 are supported on nRF54L15");
 #endif
 
 #if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
@@ -103,7 +106,7 @@ int ED25519_verify(const uint8_t *message, size_t message_len,
 
     status = PSA_ERROR_BAD_STATE;
 
-    for (int i = 0; i < KMU_KEY_COUNT; ++i) {
+    for (int i = 0; i < CONFIG_BOOT_SIGNATURE_KMU_SLOTS; ++i) {
         psa_key_id_t kid = kmu_key_ids[i];
 
         status = psa_verify_message(kid, PSA_ALG_PURE_EDDSA, message,

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -317,6 +317,18 @@ config BOOT_SIGNATURE_USING_KMU
 	  MCUboot will use keys provisioned to the device key management unit for signature
 	  verification instead of compiling in key data from a file.
 
+if BOOT_SIGNATURE_USING_KMU
+
+config BOOT_SIGNATURE_KMU_SLOTS
+	int "KMU key slots"
+	range 1 3
+	default 1
+	help
+	  Selects the number of KMU key slots (also known as generations) to use when verifying
+	  an image.
+
+endif
+
 if !BOOT_SIGNATURE_USING_KMU
 
 config BOOT_SIGNATURE_KEY_FILE


### PR DESCRIPTION
Adds a new Kconfig CONFIG_BOOT_SIGNATURE_KMU_SLOTS which allows specifying how many KMU key IDs are supported, the default is set to 1 instead of 3 which was set before