### PR TITLE
[nrf noup] boot: zephyr: serial_recovery: Add nRF5340 Kconfig override

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -47,9 +47,14 @@ config BOOT_SERIAL_CDC_ACM
 
 endchoice
 
+DT_COMPAT_SIM_FLASH:= zephyr,sim-flash
+DT_SIM_FLASH_PATH := $(dt_nodelabel_path,flash_sim0)
+
 config MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
 	bool "Allow to select image number for DFU"
-	depends on !SINGLE_APPLICATION_SLOT
+	# Allow this option to be selected in cases where support for direct uploading to nRF5340
+	# network core should be supported
+	depends on !SINGLE_APPLICATION_SLOT || (SINGLE_APPLICATION_SLOT && SOC_NRF5340_CPUAPP && BOOT_IMAGE_ACCESS_HOOK_NRF5340 && FLASH_SIMULATOR && $(dt_compat_enabled,$(DT_COMPAT_SIM_FLASH)))
 	help
 	  With the option enabled, the mcuboot serial recovery will
 	  respect the "image" field in mcumgr image update frame


### PR DESCRIPTION
Adds additional conditions that lets the direct upload option to be selected on nRF5340 to allow for uploading network core updates directly to the network core with the flash simulator

NCSDK-30866