### PR TITLE
[nrf noup] boot: bootutil: image_validate: Add KMU support to compres…

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -815,7 +815,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
         }
 
 #ifdef EXPECTED_SIG_TLV
-#ifdef EXPECTED_KEY_TLV
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && defined(EXPECTED_KEY_TLV)
         rc = bootutil_tlv_iter_begin(&it, hdr, fap, EXPECTED_KEY_TLV, false);
         if (rc) {
             goto out;
@@ -861,7 +861,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
                  */
             }
         }
-#endif /* EXPECTED_KEY_TLV */
+#endif /* !CONFIG_BOOT_SIGNATURE_USING_KMU && EXPECTED_KEY_TLV */
 
         rc = bootutil_tlv_iter_begin(&it, hdr, fap, IMAGE_TLV_DECOMP_SIGNATURE, true);
         if (rc) {
@@ -884,10 +884,12 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
 
             if (type == IMAGE_TLV_DECOMP_SIGNATURE) {
                 /* Ignore this signature if it is out of bounds. */
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
                 if (key_id < 0 || key_id >= bootutil_key_cnt) {
                     key_id = -1;
                     continue;
                 }
+#endif
 
                 if (!EXPECTED_SIG_LEN(len) || len > sizeof(buf)) {
                     rc = -1;


### PR DESCRIPTION
…sion

fixup! [nrf noup] bootutil: Add support for KMU stored ED25519 signature key

This adds the additional code required so that the compression feature can be used with keys that reside in the KMU

NCSDK-30896