### PR TITLE
[nrf noup] partition_manager: Add support for internal flash netcore DFU

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -78,11 +78,17 @@ mcuboot_pad:
 mcuboot_primary_1:
   region: ram_flash
   size: CONFIG_NRF53_RAM_FLASH_SIZE
-#endif /* CONFIG_NRF53_MULTI_IMAGE_UPDATE */
+#endif /* CONFIG_NRF53_MCUBOOT_PRIMARY_1_RAM_FLASH */
 
 #if (CONFIG_NRF53_MULTI_IMAGE_UPDATE)
 mcuboot_secondary_1:
+#if defined(CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY)
   region: external_flash
+#else
+  placement:
+    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
+    after: mcuboot_secondary
+#endif
   size: CONFIG_NRF53_RAM_FLASH_SIZE
 
 #endif /* CONFIG_NRF53_MULTI_IMAGE_UPDATE */


### PR DESCRIPTION
Adds check to region of mcuboot_secondary_1 to put it in external flash only if CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY is set.

This should allow for DFU from internal flash on the nRF5340 with dynamic partitioning.

Also fixing a typo.