### PR TITLE
[nrf noup] boot/zephyr: nrf54h20dk support

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -925,6 +925,7 @@ config BOOT_WATCHDOG_FEED_NRFX_WDT
 	imply NRFX_WDT1
 	imply NRFX_WDT30
 	imply NRFX_WDT31
+	imply NRFX_WDT010
 
 config BOOT_IMAGE_ACCESS_HOOKS
 	bool "Enable hooks for overriding MCUboot's native routines"

--- a/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
+++ b/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Ensure that the SPI NOR driver is disabled by default
+CONFIG_SPI_NOR=n
+
+# TODO: below are not yet supported and need fixing
+CONFIG_FPROTECT=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+CONFIG_MULTITHREADING=y

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -34,6 +34,12 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #define FLASH_DEVICE_BASE 0
 #define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
 
+#elif (defined(CONFIG_SOC_SERIES_NRF54HX) && DT_HAS_CHOSEN(zephyr_flash))
+
+#define FLASH_DEVICE_ID SPI_FLASH_0_ID
+#define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
+#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash)
+
 #else
 #error "FLASH_DEVICE_ID could not be determined"
 #endif

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -382,6 +382,9 @@
 #elif defined(CONFIG_NRFX_WDT31)
 #define MCUBOOT_WATCHDOG_FEED() \
     FEED_WDT_INST(31);
+#elif defined(CONFIG_NRFX_WDT010)
+#define MCUBOOT_WATCHDOG_FEED() \
+    FEED_WDT_INST(010);
 #else
 #error "No NRFX WDT instances enabled"
 #endif

--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -32,9 +32,11 @@
 /*
  * Sanity check the target support.
  */
-#if (!defined(CONFIG_XTENSA) && !DT_HAS_CHOSEN(zephyr_flash_controller)) || \
+#if (!defined(CONFIG_XTENSA) && !defined(CONFIG_SOC_SERIES_NRF54HX) && \
+    !DT_HAS_CHOSEN(zephyr_flash_controller)) || \
     (defined(CONFIG_XTENSA) && !DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)) && \
     !defined(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32)) || \
+    (defined(CONFIG_SOC_SERIES_NRF54HX) && !DT_HAS_CHOSEN(zephyr_flash)) || \
     !defined(FLASH_ALIGN) ||                  \
     !(FIXED_PARTITION_EXISTS(slot0_partition)) || \
     !(FIXED_PARTITION_EXISTS(slot1_partition) || CONFIG_SINGLE_APPLICATION_SLOT) || \

--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#if !defined(CONFIG_SOC_SERIES_NRF54HX)
 #include <hal/nrf_clock.h>
+#endif
 #include <hal/nrf_uarte.h>
 #include <haly/nrfy_uarte.h>
 #if defined(NRF_RTC0) || defined(NRF_RTC1) || defined(NRF_RTC2)
@@ -62,10 +64,12 @@ static NRF_UARTE_Type *nrf_uarte_to_clean[] = {
 };
 #endif
 
+#if !defined(CONFIG_SOC_SERIES_NRF54HX)
 static void nrf_cleanup_clock(void)
 {
     nrf_clock_int_disable(NRF_CLOCK, 0xFFFFFFFF);
 }
+#endif
 
 void nrf_cleanup_peripheral(void)
 {
@@ -109,7 +113,10 @@ void nrf_cleanup_peripheral(void)
 #if defined(NRF_DPPIC)
     nrf_dppi_channels_disable_all(NRF_DPPIC);
 #endif
+
+#if !defined(CONFIG_SOC_SERIES_NRF54HX)
     nrf_cleanup_clock();
+#endif
 }
 
 #if USE_PARTITION_MANAGER \


### PR DESCRIPTION
Added basic support for nrf54h20dk_nrf54h20_cpuapp_iron board. This commit turns off CONFIG_FPROTECT and excludes accessing hal nrf_clock.h interfaces from mcuboot for this board build.