### PR TITLE
[nrf fromtree] boot: bootutil: Fix clash of STRUCT_PACKED definition

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -36,10 +36,14 @@
 extern "C" {
 #endif
 
+#if defined(STRUCT_PACKED)
+#undef STRUCT_PACKED
+#endif
+
 #if defined(__IAR_SYSTEMS_ICC__)
-    #define STRUCT_PACKED   __packed struct
+#define STRUCT_PACKED __packed struct
 #else
-    #define STRUCT_PACKED   struct __attribute__((__packed__))
+#define STRUCT_PACKED struct __attribute__((__packed__))
 #endif
 
 struct flash_area;


### PR DESCRIPTION
Fixes an issue whereby another module might have declared this by undefining it if it's already 