### PR TITLE
[nrf noup] boot/zephyr/Kconfig: fix MBEDTLS_CFG_FILE value

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -415,7 +415,6 @@ config MBEDTLS_CFG_FILE
 	# is used, but the fact is that Mbed TLS' ASN1 parse module is used
 	# also when TinyCrypt is used as crypto backend.
 	default "mcuboot-mbedtls-cfg.h" if BOOT_USE_TINYCRYPT
-	default "config-tls-generic.h" if NRF_SECURITY && (MBEDTLS_BUILTIN || BOOT_USE_PSA_CRYPTO)
 	default "mcuboot-mbedtls-cfg.h" if BOOT_USE_MBEDTLS && !MBEDTLS_BUILTIN
 
 config BOOT_HW_KEY


### PR DESCRIPTION
Zephyr provides "mcuboot-mbedtls-cfg.h" as glue interface for configure mbedts. "config-tls-generic.h" default value was erroneously introduced during a meta codebase synchronization.