### PR TITLE
[Backport v2.1.0-ncs5-branch] [nrf fromlist] zephyr: Disable SPI_NOR by default for nrf7002dk/nrf5340/c…

### DIFF
--- a/boot/zephyr/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/boot/zephyr/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -1,0 +1,5 @@
+# By default no external SPI device is used for image storage,
+# so SPI-NOR is not needed. This reduces size of MCUboot, remember
+# though that when external image is needed the CONFIG_SPI_NOR
+# has to be enabled.
+CONFIG_SPI_NOR=n


### PR DESCRIPTION
Backport 2d52426972382579577a72c41b6030d3316ba81e from #415.