### PR TITLE
boot/zephyr/nrf_cleanup: nRF54l: disable cleanup on UARTE pins

### DIFF
--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -97,6 +97,12 @@ void nrf_cleanup_peripheral(void)
         nrfy_uarte_event_clear(current, NRF_UARTE_EVENT_RXTO);
         nrfy_uarte_disable(current);
 
+#ifndef CONFIG_SOC_SERIES_NRF54LX
+        /* Disconnect pins UARTE pins
+         * causes issues on nRF54l SoCs,
+         * could be enabled once fix to NCSDK-33039 will be implemented.
+         */
+
         uint32_t pin[4];
 
         pin[0] = nrfy_uarte_tx_pin_get(current);
@@ -111,6 +117,7 @@ void nrf_cleanup_peripheral(void)
                 nrfy_gpio_cfg_default(pin[i]);
             }
         }
+#endif
 
 #if defined(NRF_DPPIC)
         /* Clear all SUBSCRIBE configurations. */


### PR DESCRIPTION
Compile out code which does cleanup on UARTE pins as this cause issues on for some applications.

ref.: NCSDK-33039