### PR TITLE
[nrf noup] boot: zephyr: Protect only the bootloader

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -638,12 +638,12 @@ int main(void)
 
 #ifdef PM_S1_ADDRESS
 /* MCUBoot is stored in either S0 or S1, protect both */
-#define PROTECT_SIZE (PM_MCUBOOT_PRIMARY_ADDRESS - PM_S0_ADDRESS)
+#define PROTECT_SIZE (PM_S1_END_ADDRESS - PM_S0_ADDRESS)
 #define PROTECT_ADDR PM_S0_ADDRESS
 #else
 /* There is only one instance of MCUBoot */
-#define PROTECT_SIZE (PM_MCUBOOT_PRIMARY_ADDRESS - PM_MCUBOOT_ADDRESS)
 #define PROTECT_ADDR PM_MCUBOOT_ADDRESS
+#define PROTECT_SIZE PM_MCUBOOT_SIZE
 #endif
 
     rc = fprotect_area(PROTECT_ADDR, PROTECT_SIZE);


### PR DESCRIPTION
When using fprotect_area(), only protect the areas assigned to bootloader. Don't assume there is nothing between bootloader and primary slot.

This allows placing TF-M storage between bootloader and MCUboot primary slot.

![image](https://github.com/user-attachments/assets/4bb25402-4aae-4832-a2a8-f405a6b3deec)
