### PR TITLE
[nrf fromtree] bootutil: Improve HKDF code and remove BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -11,7 +11,6 @@
 #include "bootutil/bootutil_log.h"
 #include "bootutil/bootutil_public.h"
 #include "bootutil/fault_injection_hardening.h"
-#include "bootutil/enc_key.h"
 
 #include "mcuboot_config/mcuboot_config.h"
 

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -422,11 +422,11 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
     bootutil_aes_ctr_context aes_ctr;
     uint8_t tag[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint8_t shared[SHARED_KEY_LEN];
-    uint8_t derived_key[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
+    uint8_t derived_key[BOOT_ENC_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint8_t *cp;
     uint8_t *cpend;
     uint8_t private_key[PRIV_KEY_LEN];
-    uint8_t counter[BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE];
+    uint8_t counter[BOOT_ENC_BLOCK_SIZE];
     uint16_t len;
 #endif
     struct bootutil_key *bootutil_enc_key = NULL;
@@ -530,10 +530,10 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
      * Expand shared secret to create keys for AES-128-CTR + HMAC-SHA256
      */
 
-    len = BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE;
+    len = BOOT_ENC_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE;
     rc = hkdf(shared, SHARED_KEY_LEN, (uint8_t *)"MCUBoot_ECIES_v1", 16,
             derived_key, &len);
-    if (rc != 0 || len != (BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE)) {
+    if (rc != 0 || len != (BOOT_ENC_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE)) {
         return -1;
     }
 
@@ -585,8 +585,8 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
         return -1;
     }
 
-    memset(counter, 0, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
-    rc = bootutil_aes_ctr_decrypt(&aes_ctr, counter, &buf[EC_CIPHERKEY_INDEX], BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE, 0, enckey);
+    memset(counter, 0, BOOT_ENC_BLOCK_SIZE);
+    rc = bootutil_aes_ctr_decrypt(&aes_ctr, counter, &buf[EC_CIPHERKEY_INDEX], BOOT_ENC_KEY_SIZE, 0, enckey);
     if (rc != 0) {
         bootutil_aes_ctr_drop(&aes_ctr);
         return -1;

--- a/boot/bootutil/src/encrypted_psa.c
+++ b/boot/bootutil/src/encrypted_psa.c
@@ -28,10 +28,12 @@
 BOOT_LOG_MODULE_DECLARE(mcuboot_psa_enc);
 
 #define EXPECTED_ENC_LEN    BOOT_ENC_TLV_SIZE
-#define EXPECTED_ENC_TLV    IMAGE_TLV_ENC_X25519
 #define EC_PUBK_INDEX       (0)
-#define EC_TAG_INDEX        (32)
-#define EC_CIPHERKEY_INDEX  (32 + 32)
+#define EC_PUBK_LEN         (32)
+#define EC_TAG_INDEX        (EC_PUBK_INDEX + EC_PUBK_LEN)
+#define EC_TAG_LEN          (32)
+#define EC_CIPHERKEY_INDEX  (EC_TAG_INDEX + EC_TAG_LEN)
+#define EC_CIPHERKEY_LEN    BOOT_ENC_KEY_SIZE
 _Static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
         "Please fix ECIES-X25519 component indexes");
 
@@ -39,7 +41,6 @@ _Static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
 static const uint8_t ec_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG \
                                        MBEDTLS_OID_ORG_GOV X25519_OID;
 
-#define SHARED_KEY_LEN 32
 #define PRIV_KEY_LEN   32
 
 /* Fixme: This duplicates code from encrypted.c and depends on mbedtls */
@@ -180,7 +181,7 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
      */
     psa_ret = psa_key_derivation_key_agreement(&key_do, PSA_KEY_DERIVATION_INPUT_SECRET,
                                                kid, &buf[EC_PUBK_INDEX],
-                                               BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
+                                               EC_PUBK_LEN);
     psa_cleanup_ret = psa_destroy_key(kid);
     if (psa_cleanup_ret != PSA_SUCCESS) {
         BOOT_LOG_WRN("Built-in key destruction failed %d", psa_cleanup_ret);
@@ -242,9 +243,9 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
 
     /* Verify the MAC tag of the random encryption key */
     psa_ret = psa_mac_verify(kid, PSA_ALG_HMAC(PSA_ALG_SHA_256),
-                             &buf[EC_CIPHERKEY_INDEX], BOOT_ENC_KEY_SIZE,
+                             &buf[EC_CIPHERKEY_INDEX], EC_CIPHERKEY_LEN,
                              &buf[EC_TAG_INDEX],
-                             BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
+                             EC_TAG_LEN);
     psa_cleanup_ret = psa_destroy_key(kid);
     if (psa_cleanup_ret != PSA_SUCCESS) {
         BOOT_LOG_WRN("MAC key destruction failed %d", psa_cleanup_ret);


### PR DESCRIPTION
Provide proper identifiers for size and partitioning of the HKDF output.
