### PR TITLE
[nrf noup] bootutil: Add error log on KMU not provisioned

### DIFF
--- a/boot/bootutil/src/ed25519_psa.c
+++ b/boot/bootutil/src/ed25519_psa.c
@@ -126,6 +126,9 @@ int ED25519_verify(const uint8_t *message, size_t message_len,
         }
 
         BOOT_LOG_ERR("ED25519 signature verification failed %d", status);
+        if(status == PSA_ERROR_INVALID_HANDLE) {
+            BOOT_LOG_ERR("This error(-136) could mean that the KMU slot is not provisioned.");
+        }
     }
 
     return ret;


### PR DESCRIPTION
An unprovisioned KMU can cause confusion, so improve the logs for this case.