### PR TITLE
[nrf fromtree] boot/zephyr/main: fix placement of pointer to arm vector

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -164,7 +164,10 @@ struct arm_vector_table {
 
 static void do_boot(struct boot_rsp *rsp)
 {
-    struct arm_vector_table *vt;
+    /* vt is static as it shall not land on the stack,
+     * as this procedure modifies stack pointer before usage of *vt
+     */
+    static struct arm_vector_table *vt;
 
     /* The beginning of the image is the ARM vector table, containing
      * the initial stack pointer address and the reset vector


### PR DESCRIPTION
pointer to the image ARM vector table should be placed out of stack which is being reconfigured before vt is used for branch to the application. This caused transient boot failure when CONFIG_LTO=y.

Moved vt to static data scope.


(cherry picked from commit 264f6ee9964d726f89da94acb55d859a6278e3c6)