### PR TITLE
[nrf fromtree] boot/zephyr/main: fix placement of pointer to arm vector

### DIFF
--- a/.github/workflows/zephyr_build.yaml
+++ b/.github/workflows/zephyr_build.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Zephyr
         working-directory: repos/zephyr
         run: |
-          west config --system manifest.project-filter -- -.*,+cmsis,+hal_nordic,+hal_nxp,+hal_stm32,+libmetal,+littlefs,+mbedtls,+mcuboot,+open-amp,+picolibc,+segger,+tinycrypt,+trusted-firmware-m,+zcbor
+          west config --system manifest.project-filter -- -.*,+cmsis,+cmsis_6,+hal_nordic,+hal_nxp,+hal_stm32,+libmetal,+littlefs,+mbedtls,+mcuboot,+open-amp,+picolibc,+segger,+tinycrypt,+trusted-firmware-m,+zcbor
           west init -l .
           west update
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -164,7 +164,10 @@ struct arm_vector_table {
 
 static void do_boot(struct boot_rsp *rsp)
 {
-    struct arm_vector_table *vt;
+    /* vt is static as it shall not land on the stack,
+     * as this procedure modifies stack pointer before usage of *vt
+     */
+    static struct arm_vector_table *vt;
 
     /* The beginning of the image is the ARM vector table, containing
      * the initial stack pointer address and the reset vector


### PR DESCRIPTION
PR cherry-picks fixes for boot failures when MCUboot is used with LTO.