### PR TITLE
decompression: Add nrf54h20 iron board support

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -348,7 +348,6 @@ class Image:
                     self.payload = copy.copy(self.infile_data)
         except FileNotFoundError:
             raise click.UsageError("Input file not found")
-        self.image_size = len(self.payload)
 
         # Add the image header if needed.
         if self.pad_header and self.header_size > 0:
@@ -357,6 +356,8 @@ class Image:
                 self.base_addr -= self.header_size
             self.payload = bytes([self.erased_val] * self.header_size) + \
                 self.payload
+
+        self.image_size = len(self.payload) - self.header_size
 
         self.check_header()
 
@@ -366,14 +367,19 @@ class Image:
         self.image_size = len(self.payload)
 
         # Add the image header if needed.
-        if self.pad_header and self.header_size > 0:
-            if self.base_addr:
-                # Adjust base_addr for new header
-                self.base_addr -= self.header_size
-            self.payload = bytes([self.erased_val] * self.header_size) + \
-                self.payload
-
-        self.check_header()
+        if self.header_size > 0:
+            if self.pad_header:
+                if self.base_addr:
+                    # Adjust base_addr for new header
+                    self.base_addr -= self.header_size
+                self.payload = bytes([self.erased_val] * self.header_size) + \
+                    self.payload
+            else:
+                # Fill header padding with zeros to align with what is expected
+                # for uncompressed images when no pad_header is requested
+                # (see self.check_header())
+                self.payload = bytes([0] * self.header_size) + \
+                    self.payload
 
     def save(self, path, hex_addr=None):
         """Save an image from a given file"""

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -542,9 +542,11 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
         ]
         if compression == "lzma2armthumb":
             compression_filters.insert(0, {"id":lzma.FILTER_ARMTHUMB})
-        compressed_data = lzma.compress(img.get_infile_data(),filters=compression_filters,
-            format=lzma.FORMAT_RAW)
-        uncompressed_size = len(img.get_infile_data())
+
+        infile_offset = 0 if pad_header else header_size
+        compressed_data = lzma.compress(img.get_infile_data()[infile_offset:],
+            filters=compression_filters, format=lzma.FORMAT_RAW)
+        uncompressed_size = len(img.get_infile_data()[infile_offset:])
         compressed_size = len(compressed_data)
         print(f"compressed image size: {compressed_size} bytes")
         print(f"original image size: {uncompressed_size} bytes")


### PR DESCRIPTION
This PR aligns flash writes to any boundaries returned by
flash_area_align() instead of using a fixed 4-byte alignment.
    
This change ensures that the decompression code works correctly with
flash areas that may require different alignment, such as those
used by the nRF54H20 SoC.
    
This PR also fixes following issues:
 - hash calculation of header padding with bytes other than
   flash 'erased value' (may be 0x00)
 - buffer overflow from previous approach of caching unaligned
   ARM thumb filter output. For 'excess_data_buffer_full == true',
   decomp_buf could be of DECOMP_BUF_ALLOC_SIZE size already before
   moving and restoring cached data to the beginning of the buffer.
 - missing ARM thumb cached bytes restoration after leaving main
   decompression loop.
- in imgtool, fixes issues when trying to compress images with no
    header padding requested.

