### PR TITLE
[nrf fromlist] bootutil: Fix boot_scramble_region escaping flash area

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1690,7 +1690,7 @@ boot_scramble_region(const struct flash_area *fa, uint32_t off, uint32_t size, b
             end_offset = ALIGN_DOWN((off + size), write_block);
         }
 
-        while (true) {
+        while (off != end_offset) {
             /* Write over the area to scramble data that is there */
             rc = flash_area_write(fa, off, buf, write_block);
             if (rc != 0) {
@@ -1707,12 +1707,12 @@ boot_scramble_region(const struct flash_area *fa, uint32_t off, uint32_t size, b
 
                 off -= write_block;
             } else {
-                if (end_offset < off) {
+                off += write_block;
+
+                if (end_offset <= off) {
                     /* Reached the end offset in range and already scrambled it */
                     break;
                 }
-
-                off += write_block;
             }
         }
     }


### PR DESCRIPTION
Incorrect range check fix.

Upstream PR #: 2337