### PR TITLE
[nrf noup] boot: bootutil: loader: Fix scope of NSIB variable

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -3075,7 +3075,6 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
              */
         }
 
-#ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
 #ifdef PM_S1_ADDRESS
         /* Patch needed for NCS. Image 1 primary is the currently
          * executing MCUBoot image, and is therefore already validated by NSIB and
@@ -3083,6 +3082,10 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
          */
         bool image_validated_by_nsib = BOOT_CURR_IMG(state) ==
                                        CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER;
+#endif
+
+#ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
+#ifdef PM_S1_ADDRESS
         if (!image_validated_by_nsib)
 #endif
         {


### PR DESCRIPTION
nrf-squash! [nrf noup] treewide: Add support for sysbuild assigned images

Fixes the wrong scope of a variable which would cause a compilation to fail if b0 is enabled and slot0 validation is not enabled