### PR TITLE
[nrf noup] bootutil: Locking KMU keys

### DIFF
--- a/boot/bootutil/src/ed25519_psa.c
+++ b/boot/bootutil/src/ed25519_psa.c
@@ -165,4 +165,34 @@ out:
     return ret;
 }
 #endif /* CONFIG_BOOT_KMU_KEYS_REVOCATION */
+
+void nrf_crypto_keys_housekeeping(void)
+{
+    psa_status_t status;
+
+    /* We will continue through all keys, even if we have error while
+     * processing any of it. Only doing BOOT_LOG_DBG, as we do not
+     * really want to inform on failures to lock.
+     */
+    for (int i = 0; i < CONFIG_BOOT_SIGNATURE_KMU_SLOTS; ++i) {
+        psa_key_attributes_t attr;
+
+        status = psa_get_key_attributes(kmu_key_ids[i], &attr);
+        BOOT_LOG_DBG("KMU key 0x%x(%d) attr query status == %d",
+                     kmu_key_ids[i], i, status);
+
+        if (status == PSA_SUCCESS) {
+            status = cracen_kmu_block(&attr);
+            BOOT_LOG_DBG("KMU key lock status == %d", status);
+        }
+
+#if !defined(CONFIG_PSA_CORE_LITE)
+        status = psa_purge_key(kmu_key_ids[i]);
+        BOOT_LOG_DBG("KMU key 0x%x(%d) purge status == %d",
+                     kmu_key_ids[i], i, status);
+#endif
+
+    }
+}
+
 #endif

--- a/boot/zephyr/include/nrf_cleanup.h
+++ b/boot/zephyr/include/nrf_cleanup.h
@@ -21,4 +21,15 @@ void nrf_cleanup_peripheral(void);
  */
 void nrf_cleanup_ns_ram(void);
 
+/**
+ * Crypto key storage housekeeping. Intended to clean up key objects from
+ * crypto backend and apply key policies that should take effect after
+ * MCUboot no longer needs access to keys.
+ */
+#if defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
+extern void nrf_crypto_keys_housekeeping(void);
+#else
+#define nrf_crypto_keys_housekeeping() do {} while (0)
+#endif
+
 #endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -768,6 +768,13 @@ int main(void)
 
     mcuboot_status_change(MCUBOOT_STATUS_BOOTABLE_IMAGE_FOUND);
 
+    /* From this point MCUboot does not need access to crypto keys.
+     * Clean up backend key objects and apply key access policies that
+     * will take effect from now through entire boot session and application
+     * run.
+     */
+    nrf_crypto_keys_housekeeping();
+
 #if USE_PARTITION_MANAGER && CONFIG_FPROTECT
 
 #ifdef PM_S1_ADDRESS


### PR DESCRIPTION
Lock KMU keys before passing execution to application.

manifest-pr-skip