### PR TITLE
Bring down upstream defined control over support for TLV allow list 

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -471,7 +471,7 @@ static int bootutil_check_for_pure(const struct image_header *hdr,
 }
 #endif
 
-#ifndef ALLOW_ROGUE_TLVS
+#ifdef MCUBOOT_USE_TLV_ALLOW_LIST
 /*
  * The following list of TLVs are the only entries allowed in the unprotected
  * TLV section.  All other TLV entries must be in the protected section.
@@ -701,7 +701,7 @@ bootutil_img_validate(struct boot_loader_state *state,
             break;
         }
 
-#ifndef ALLOW_ROGUE_TLVS
+#ifdef MCUBOOT_USE_TLV_ALLOW_LIST
         /*
          * Ensure that the non-protected TLV only has entries necessary to hold
          * the signature.  We also allow encryption related keys to be in the

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1214,6 +1214,18 @@ config MCUBOOT_BOOT_BANNER
 config BOOT_BANNER_STRING
         default "Using Zephyr OS build" if MCUBOOT_BOOT_BANNER
 
+config MCUBOOT_USE_TLV_ALLOW_LIST
+	bool "Check unprotected TLVs against allow list"
+	default y
+	help
+	  Every unprotected TLV will be checked against list of allowed TLVs,
+	  which is compiled in and depends on configuration; an image that
+	  contain TLV not present on the list will be automaticaly rejected.
+	  This is additional check, as MCUboot will not be parsing TLVs it
+	  has not been compiled to parse in the first place.
+	  Disabling this option will cut down MCUboot size.
+	  The Kconfig controlls MCUboot configuration option MCUBOOT_USE_TLV_ALLOW_LIST.
+
 config BOOT_DECOMPRESSION_SUPPORT
 	bool
 	depends on NRF_COMPRESS && NRF_COMPRESS_DECOMPRESSION && (NRF_COMPRESS_LZMA_VERSION_LZMA1 || NRF_COMPRESS_LZMA_VERSION_LZMA2)

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -148,6 +148,11 @@
 #define MCUBOOT_HAVE_LOGGING 1
 #endif
 
+/* Enable/disable non-protected TLV check against allow list */
+#ifdef CONFIG_MCUBOOT_USE_TLV_ALLOW_LIST
+#define MCUBOOT_USE_TLV_ALLOW_LIST 1
+#endif
+
 #ifdef CONFIG_BOOT_ENCRYPT_RSA
 #define MCUBOOT_ENC_IMAGES
 #define MCUBOOT_ENCRYPT_RSA

--- a/docs/release-notes.d/tlv-allow-list.md
+++ b/docs/release-notes.d/tlv-allow-list.md
@@ -1,0 +1,2 @@
+ - Control over compilation of unprotected TLV allow list has been exposed
+   using MCUBOOT_USE_TLV_ALLOW_LIST mcuboot configuration identifier.


### PR DESCRIPTION
MCUboot image validation and Zephyr Kconfig changes.

manifest-pr-skip