### PR TITLE
[nrf noup] boot/zephyr/nrf_cleanup: fix index error

### DIFF
--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -131,7 +131,7 @@ void nrf_cleanup_peripheral(void)
 
         for (int j = 0; j < 4; j++) {
             if (pin[j] != NRF_UARTE_PSEL_DISCONNECTED) {
-                nrfy_gpio_cfg_default(pin[i]);
+                nrfy_gpio_cfg_default(pin[j]);
             }
         }
 #endif


### PR DESCRIPTION
Fix indexing variable mismatch.