### PR TITLE
[nrf noup] boot: zephyr: Disable self RWX

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -472,6 +472,13 @@ config MCUBOOT_CLEANUP_RAM
 	help
 	  Sets contents of memory to 0 before jumping to application.
 
+config NCS_MCUBOOT_DISABLE_SELF_RWX
+	bool "Disable read and execution on self NVM"
+	depends on (SOC_NRF54L15_CPUAPP || SOC_NRF54L10_CPUAPP || SOC_NRF54L05_CPUAPP) && !FPROTECT
+	help
+	  Sets RRAMC's region no.4 protection before jumping to application.
+	  It disables reads writes and execution memory area which holds MCUBOOT.
+
 config MCUBOOT_INFINITE_LOOP_AFTER_RAM_CLEANUP
 	bool "Infinite loop after RAM cleanup"
 	depends on MCUBOOT_CLEANUP_RAM


### PR DESCRIPTION
Disables read write and execute on mcuboots NVM
at the end of execution.