### PR TITLE
[Backport ncs-v3.1-branch] Series of commits that defult to HMAC-SHA512 for X25519 on NRF54L

### DIFF
--- a/boot/bootutil/src/encrypted_psa.c
+++ b/boot/bootutil/src/encrypted_psa.c
@@ -43,7 +43,11 @@ static const uint8_t ec_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG \
 #define HKDF_AES_KEY_SIZE   (BOOT_ENC_KEY_SIZE)
 /* MAC feed */
 #define HKDF_MAC_FEED_INDEX (HKDF_AES_KEY_INDEX + HKDF_AES_KEY_SIZE)
-#define HKDF_MAC_FEED_SIZE  (32)    /* This is SHA independent */
+#if !defined(MCUBOOT_HMAC_SHA512)
+#define HKDF_MAC_FEED_SIZE  (32)
+#else
+#define HKDF_MAC_FEED_SIZE  (64)
+#endif
 /* Total size */
 #define HKDF_SIZE           (HKDF_AES_KEY_SIZE + HKDF_MAC_FEED_SIZE)
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -728,6 +728,7 @@ if BOOT_ENCRYPT_X25519 && BOOT_USE_PSA_CRYPTO
 
 choice BOOT_HMAC_SHA
 	prompt "SHA used for HMAC and HKDF in encryption key exchange"
+	default BOOT_HMAC_SHA512 if BOOT_ENCRYPT_X25519 && (SOC_NRF54L15_CPUAPP || SOC_NRF54LM20A_ENGA_CPUAPP)
 	default BOOT_HMAC_SHA256
 	help
 	  HMAC/HKDF sha algorithm may be selected to synchronize sha

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -444,7 +444,7 @@ class Image:
             newpk = X25519PrivateKey.generate()
             shared = newpk.exchange(enckey._get_public())
         derived_key = HKDF(
-            algorithm=hmac_sha_alg, length=48, salt=None,
+            algorithm=hmac_sha_alg, length=16 + hmac_sha_alg.digest_size, salt=None,
             info=b'MCUBoot_ECIES_v1', backend=default_backend()).derive(shared)
         encryptor = Cipher(algorithms.AES(derived_key[:16]),
                            modes.CTR(bytes([0] * 16)),


### PR DESCRIPTION
Backport 8b2d04cba336b40f97b1c5edbef80f4e58fa1a90~3..8b2d04cba336b40f97b1c5edbef80f4e58fa1a90 from #483.