### PR TITLE
[Backport ncs-v3.1-branch] [nrf noup] boot/zephyr/nrf_cleanup: fix index error

### DIFF
--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -131,7 +131,7 @@ void nrf_cleanup_peripheral(void)
 
         for (int j = 0; j < 4; j++) {
             if (pin[j] != NRF_UARTE_PSEL_DISCONNECTED) {
-                nrfy_gpio_cfg_default(pin[i]);
+                nrfy_gpio_cfg_default(pin[j]);
             }
         }
 #endif


### PR DESCRIPTION
Backport 58175b6f71bdae10e1d10896c1c858520ab583ec from #490.