### PR TITLE
boot: zephyr: Adjust PSA requirements for PSA_CORE_LITE

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -74,14 +74,14 @@ if BOOT_USE_PSA_CRYPTO
 config BOOT_PSA_IMG_HASH_ALG_SHA256_DEPENDENCIES
 	bool
 	default y if BOOT_SOMETHING_USES_SHA256
-	select PSA_WANT_ALG_SHA_256 if !PSA_CORE_LITE
+	select PSA_WANT_ALG_SHA_256
 	help
 	  Dependencies for hashing with SHA256
 
 config BOOT_PSA_IMG_HASH_ALG_SHA512_DEPENDENCIES
 	bool
 	default y if BOOT_SOMETHING_USES_SHA512
-	select PSA_WANT_ALG_SHA_512 if !PSA_CORE_LITE
+	select PSA_WANT_ALG_SHA_512
 	help
 	  Dependencies for hashing with SHA512
 


### PR DESCRIPTION
nrf-squash! [nrf noup] boot: zephyr: Kconfig dependencies for PSA LITE

The PSA core lite now requires the PSA_WANTs for the hashing functions to be set in order to be used so select them as normal.