### PR TITLE
[nrf fromlist] boot/boot_serial: build-time skip of the erasing of im…

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -77,6 +77,12 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
+#if !(defined(MCUBOOT_SINGLE_APPLICATION_SLOT) || \
+    defined(MCUBOOT_FIRMWARE_LOADER) ||           \
+    defined(MCUBOOT_SINGLE_APPLICATION_SLOT_RAM_LOAD))
+#define BOOT_IMAGE_HAS_STATUS_FIELDS
+#endif
+
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE ZCBOR_ARRAY_SIZE
 #endif
@@ -914,8 +920,10 @@ bs_upload(char *buf, int len)
                                          * erase has stopped to let us know whether erase
                                          * is needed to be able to write current chunk.
                                          */
+#ifdef BOOT_IMAGE_HAS_STATUS_FIELDS
     static struct flash_sector status_sector;
 #endif
+#endif /* MCUBOOT_ERASE_PROGRESSIVELY */
 #ifdef MCUBOOT_SWAP_USING_OFFSET
     static uint32_t start_off = 0;
 #endif
@@ -988,7 +996,7 @@ bs_upload(char *buf, int len)
 #endif
 
         curr_off = 0;
-#ifdef MCUBOOT_ERASE_PROGRESSIVELY
+#if defined(MCUBOOT_ERASE_PROGRESSIVELY) && defined(BOOT_IMAGE_HAS_STATUS_FIELDS)
         /* Get trailer sector information; this is done early because inability to get
          * that sector information means that upload will not work anyway.
          * TODO: This is single occurrence issue, it should get detected during tests
@@ -1167,7 +1175,7 @@ bs_upload(char *buf, int len)
     if (rc == 0) {
         curr_off += img_chunk_len + rem_bytes;
         if (curr_off == img_size) {
-#ifdef MCUBOOT_ERASE_PROGRESSIVELY
+#if defined(MCUBOOT_ERASE_PROGRESSIVELY) && defined(BOOT_IMAGE_HAS_STATUS_FIELDS)
             /* Assure that sector for image trailer was erased. */
             /* Check whether it was erased during previous upload. */
             off_t start = flash_sector_get_off(&status_sector);


### PR DESCRIPTION
…g status page

For MCUboot's MCUBOOT_SINGLE_APPLICATION_SLOT, MCUBOOT_FIRMWARE_LOADER, MCUBOOT_SINGLE_APPLICATION_SLOT_RAM_LOAD
modes there is not image run-time status data at the end on the image. Erase of that was done as the last image page erase - and was no harm before by luck.

Following commit just reveled the issue:
 #35536633846b53ccdf01bea0594526de4b416fc0

Upstream PR #: 2417

backport of #507