### PR TITLE
[nrf fromlist] bootutil: swap_scratch: Fix scratch scrambling

### DIFF
--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -926,7 +926,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
             * happens then the scratch which is partially erased would be wrote back to the
             * primary slot, causing a corrupt unbootable image
             */
-            rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch), true);
+            rc = boot_scramble_region(fap_scratch, 0, flash_area_get_size(fap_scratch), true);
             assert(rc == 0);
         }
     }


### PR DESCRIPTION
This PR fixes the scrambling of the scratch area after persisting a trailer to the primary slot. Previous use of boot_erase_region() didn't guarantee that the scratch area is scrambled, as it only erases memory for devices that selects CONFIG_MCUBOOT_STORAGE_WITH_ERASE.

Upstream PR #: 2418