### PR TITLE
[nrf fromtree] bootutil: Fix bootutil_aes_ctr_drop memset usage

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -58,7 +58,7 @@ void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx);
 
 static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
 {
-    memset(ctx, 0, sizeof(ctx));
+    memset(ctx, 0, sizeof(*ctx));
 }
 
 static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)


### PR DESCRIPTION
memset was given incorrectly pointer size, instead of object size.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
(cherry picked from commit aa229135b30e6ce9a24c9ae2cf3a85591d1aa7d6)