### PR TITLE
boot: zephyr: boards: add chosen boot part nrf54h20 cpuapp overlay

### DIFF
--- a/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -51,3 +51,14 @@
 &gpio_pad_group9 {
 	status = "disabled";
 };
+
+/*
+ * Copy from app.overlay as the board overlay take precedence
+ * over app overlay.
+ */
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
Add the required zephyr,boot-partition to chosen node of the nrf54h20dk_nrf54h20_cpuapp overlay as the the board overlay overwrites the common app.overlay.