### PR TITLE
[nrf noup] boot: zephyr: remove nonsecure ram cleanup

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -755,7 +755,7 @@ if(SYSBUILD)
   set(mcuboot_image_upgrade_footer_size ${required_upgrade_size} CACHE INTERNAL "Estimated MCUboot update image trailer size" FORCE)
 endif()
 
-if(CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL OR CONFIG_MCUBOOT_CLEANUP_NONSECURE_RAM)
+if(CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL)
 zephyr_library_sources(
   ${BOOT_DIR}/zephyr/nrf_cleanup.c
 )

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -144,7 +144,7 @@ K_SEM_DEFINE(boot_log_sem, 1, 1);
 #include <pm_config.h>
 #endif
 
-#if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL || CONFIG_MCUBOOT_NRF_CLEANUP_NONSECURE_RAM
+#if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL
 #include <nrf_cleanup.h>
 #endif
 
@@ -223,9 +223,6 @@ static void do_boot(struct boot_rsp *rsp)
 #endif
 #if CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL
     nrf_cleanup_peripheral();
-#endif
-#if CONFIG_MCUBOOT_NRF_CLEANUP_NONSECURE_RAM && defined(PM_SRAM_NONSECURE_NAME)
-    nrf_cleanup_ns_ram();
 #endif
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
     cleanup_arm_nvic(); /* cleanup NVIC registers */

--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -158,12 +158,3 @@ void nrf_cleanup_peripheral(void)
     nrf_cleanup_clock();
 #endif
 }
-
-#if USE_PARTITION_MANAGER \
-	&& defined(CONFIG_ARM_TRUSTZONE_M) \
-	&& defined(PM_SRAM_NONSECURE_NAME)
-void nrf_cleanup_ns_ram(void)
-{
-	memset((void *) PM_SRAM_NONSECURE_ADDRESS, 0, PM_SRAM_NONSECURE_SIZE);
-}
-#endif


### PR DESCRIPTION
This leads to stack corruption.