### PR TITLE
[nrf noup] boot: zephyr: Delay bm IO button check

### DIFF
--- a/boot/zephyr/io_bm.c
+++ b/boot/zephyr/io_bm.c
@@ -93,6 +93,9 @@ bool io_detect_pin(void)
 
     nrf_gpio_cfg_input(BOARD_PIN_BTN_0, BM_BUTTONS_PIN_PULLUP);
 
+    /* Delay 5 us for pull-up to be applied */
+    k_busy_wait(5);
+
     pin_active = (bool)nrf_gpio_pin_read(BOARD_PIN_BTN_0);
 
     if (!pin_active) {


### PR DESCRIPTION
nrf-squash! [nrf noup] boot: zephyr: Add bm firmware loader code

Delays checking IO button state by 5us after pull-up has been applied to allow time for it to be applied