### PR TITLE
[nrf noup] Support for ed25519 signature verification using ITS

### DIFF
--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -36,6 +36,7 @@ extern int ED25519_verify(const uint8_t *message, size_t message_len,
 
 #if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
 #if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
+#if !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS)
 /*
  * Parse the public key used for signing.
  */
@@ -78,6 +79,7 @@ bootutil_import_key(uint8_t **cp, uint8_t *end)
 }
 #endif /* !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN) */
 #endif
+#endif
 
 /* Signature verification base function.
  * The function takes buffer of specified length and tries to verify
@@ -93,7 +95,7 @@ bootutil_verify(uint8_t *buf, uint32_t blen,
     int rc;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
     uint8_t *pubkey = NULL;
-#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS)
     uint8_t *end;
 #endif
 
@@ -106,7 +108,7 @@ bootutil_verify(uint8_t *buf, uint32_t blen,
         goto out;
     }
 
-#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS)
     pubkey = (uint8_t *)bootutil_keys[key_id].key;
     end = pubkey + *bootutil_keys[key_id].len;
 

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -772,13 +772,13 @@ bootutil_img_validate(struct boot_loader_state *state,
         case EXPECTED_SIG_TLV:
         {
             BOOT_LOG_DBG("bootutil_img_validate: EXPECTED_SIG_TLV == %d", EXPECTED_SIG_TLV);
-#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS)
             /* Ignore this signature if it is out of bounds. */
             if (key_id < 0 || key_id >= bootutil_key_cnt) {
                 key_id = -1;
                 continue;
             }
-#endif /* !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) */
+#endif /* !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS) */
             if (!EXPECTED_SIG_LEN(len) || len > sizeof(buf)) {
                 rc = -1;
                 goto out;
@@ -1022,7 +1022,7 @@ skip_security_counter_check:
 
             if (type == IMAGE_TLV_DECOMP_SIGNATURE) {
                 /* Ignore this signature if it is out of bounds. */
-#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
+#if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS)
                 if (key_id < 0 || key_id >= bootutil_key_cnt) {
                     key_id = -1;
                     continue;


### PR DESCRIPTION
Thic PR introduces support for ed25519 signature verification when CONFIG_NCS_BOOT_SIGNATURE_USING_ITS is set (through PSA API).