### PR TITLE
[nrf noup] boot: zephyr: Add source of const file

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+source "$(KCONFIG_ENV_FILE)"
+
 mainmenu "MCUboot configuration"
 
 comment "MCUboot-specific configuration options"


### PR DESCRIPTION
nrf-squash! [nrf noup] treewide: add NCS partition manager support

Adds sourcing of the environmental file so that it can reference module Kconfigs