### PR TITLE
[Backport ncs-v3.1-branch] [nrf fromtree] bootutil: Fix bootutil_aes_ctr_drop memset usage

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -58,7 +58,7 @@ void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx);
 
 static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
 {
-    memset(ctx, 0, sizeof(ctx));
+    memset(ctx, 0, sizeof(*ctx));
 }
 
 static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)


### PR DESCRIPTION
Backport 5af259f253d5e11a3ab6b99de122b2e8db6fa5c7 from #511.