### PR TITLE
[nrf noup] boot: Fix test failing with bootloader requests

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -524,10 +524,12 @@ send_boot_request(uint8_t magic, uint8_t image_ok, bool confirm, int image_id,
             } else {
                 rc = 0;
             }
-#ifdef CONFIG_NCS_MCUBOOT_BOOT_REQUEST_TEST_SETS_BOOT_PREFERENCE
         } else {
+#ifdef CONFIG_NCS_MCUBOOT_BOOT_REQUEST_TEST_SETS_BOOT_PREFERENCE
             BOOT_LOG_DBG("Set image preference: %d, %d", image_id, slot_id);
             rc = boot_request_set_preferred_slot(image_id, slot_id);
+#else
+            rc = 0;
 #endif /* CONFIG_NCS_MCUBOOT_BOOT_REQUEST_TEST_SETS_BOOT_PREFERENCE */
         }
         if (rc != 0) {


### PR DESCRIPTION
nrf-squash! [nrf noup] boot: Improve bootloader request handling

Setting "test" for image was failing when using bootloader requests due to an incorrect value being returned
from send_boot_request.