### PR TITLE
[nrf noup] boot/zephyr: improve S2RAM resume support using dedicated API

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -491,7 +491,7 @@ zephyr_library_sources(
 )
 endif()
 
-if(CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE)
+if(CONFIG_PM_S2RAM_RESUME_INTERMEDIARY)
   zephyr_library_sources(${BOOT_DIR}/zephyr/nrf54h20_custom_s2ram.c)
 endif()
 

--- a/boot/zephyr/nrf54h20_custom_s2ram.c
+++ b/boot/zephyr/nrf54h20_custom_s2ram.c
@@ -30,18 +30,6 @@ volatile struct mcuboot_resume_s mcuboot_resume;
      COND_CODE_0(DT_FIXED_PARTITION_EXISTS(DT_NODELABEL(node_label)), (0), \
         (DT_REG_ADDR(DT_GPARENT(DT_NODELABEL(node_label))))))
 
-
-int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
-{
-    (void)(system_off);
-    return -1;
-}
-
-void pm_s2ram_mark_set(void)
-{
-    /* empty */
-}
-
 struct arm_vector_table {
     uint32_t msp;
     uint32_t reset;
@@ -52,13 +40,13 @@ struct arm_vector_table {
  */
 #define APP_EXE_START_OFFSET 0x800 /* nRF54H20 */
 
-bool pm_s2ram_mark_check_and_clear(void)
+void pm_s2ram_mark_check_and_mediate(void)
 {
     uint32_t reset_reason = nrf_resetinfo_resetreas_local_get(NRF_RESETINFO);
 
     if (reset_reason != NRF_RESETINFO_RESETREAS_LOCAL_UNRETAINED_MASK) {
         /* Normal boot */
-        return false;
+        return;
     }
 
     /* S2RAM resume expected, do doublecheck */
@@ -92,6 +80,4 @@ bool pm_s2ram_mark_check_and_clear(void)
 
 resume_failed:
     FIH_PANIC;
-
-    return true;
 }

--- a/boot/zephyr/socs/nrf54h20_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54h20_cpuapp.conf
@@ -7,7 +7,4 @@
 # after suspend to RAM (S2RAM) requested by the application.
 # MCUboot does not support S2RAM itself, but serves as an immediate actor while waking up
 # from suspension.
-CONFIG_PM=y
-CONFIG_PM_S2RAM=y
-CONFIG_PM_S2RAM_CUSTOM_MARKING=y
-CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE=y
+CONFIG_PM_S2RAM_RESUME_INTERMEDIARY=y


### PR DESCRIPTION
CONFIG_PM_S2RAM_RESUME_INTERMEDIARY=y allow to rework the resume from S2RAM code to work without PM_S2RAM mocking. Its allow to implement only what really needed from the MCUboot perspective.

manifest-pr-skip

