### PR TITLE
[nrf noup] nRF54h20: support for S2RAM resume for DIRECT-XIP mode

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -84,6 +84,10 @@ int pcd_version_cmp_net(const struct flash_area *fap, struct image_header *hdr);
 #include "bootutil/key_revocation.h"
 #endif
 
+#ifdef CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE
+void s2ram_designate_slot(uint8_t slot);
+#endif
+
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 static struct boot_loader_state boot_data;
@@ -3599,6 +3603,11 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
             goto close;
         }
     }
+
+#ifdef CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE
+    /* Designate the slot to be used by the PM_S2RAM resume module */
+    s2ram_designate_slot((uint8_t)state->slot_usage[0].active_slot);
+#endif
 
     /* All image loaded successfully. */
 #ifdef MCUBOOT_HAVE_LOGGING


### PR DESCRIPTION
Added direct-xip support to pm_s2ram nRF54h bootloader's resume implementation:
* new API for marking active slot to be used by boot_go() routines.
* jump vector assignment which is basing on above designation.

Dragged in above feature into boot_go() using API provided.

manifest-pr-skip