### PR TITLE
[nrf fromtree] bootutil: Fix minor issues

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -563,6 +563,9 @@ static int flash_area_to_image_slot(const struct flash_area *fa, uint32_t *slot)
 
         ++i;
     }
+
+    /* Image not found */
+    *slot = UINT32_MAX;
 #else
     (void)fa;
     if (slot != NULL) {

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -612,7 +612,7 @@ boot_verify_slot_dependencies(struct boot_loader_state *state, uint32_t slot)
 
 #ifdef MCUBOOT_VERSION_CMP_USE_SLOT_NUMBER
         /* Validate against possible dependency slot values. */
-        switch(dep->slot) {
+        switch(dep.slot) {
             case VERSION_DEP_SLOT_ACTIVE:
             case VERSION_DEP_SLOT_PRIMARY:
             case VERSION_DEP_SLOT_SECONDARY:


### PR DESCRIPTION
Fix uninitialized variable warning as well as compile time issue, when the slotted dependencies are enabled.

Upstream PR #: 2477