### PR TITLE
Modify MCUboot to use PSA key_id_t for key type in AES encryption context

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -10,8 +10,6 @@
 #ifndef __BOOTUTIL_CRYPTO_AES_CTR_H_
 #define __BOOTUTIL_CRYPTO_AES_CTR_H_
 
-#include <string.h>
-
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
@@ -19,136 +17,16 @@
     #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT or PSA"
 #endif
 
-#include "bootutil/enc_key_public.h"
-
 #if defined(MCUBOOT_USE_MBED_TLS)
-    #include <mbedtls/aes.h>
-    #define BOOT_ENC_BLOCK_SIZE (16)
+    #include "bootutil/crypto/aes_ctr_mbedtls.h"
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 #if defined(MCUBOOT_USE_TINYCRYPT)
-    #include <string.h>
-    #include <tinycrypt/aes.h>
-    #include <tinycrypt/ctr_mode.h>
-    #include <tinycrypt/constants.h>
-    #if defined(MCUBOOT_AES_256) || (BOOT_ENC_KEY_SIZE != TC_AES_KEY_SIZE)
-        #error "Cannot use AES-256 for encryption with Tinycrypt library."
-    #endif
-    #define BOOT_ENC_BLOCK_SIZE TC_AES_BLOCK_SIZE
+    #include "bootutil/crypto/aes_ctr_tinycrypt.h"
 #endif /* MCUBOOT_USE_TINYCRYPT */
 
 #if defined(MCUBOOT_USE_PSA_CRYPTO)
-    #include <psa/crypto.h>
-    #define BOOT_ENC_BLOCK_SIZE (16)
-#endif
-
-#include <stdint.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#if defined(MCUBOOT_USE_PSA_CRYPTO)
-typedef struct {
-	/* Fixme: This should not be, here, psa_key_id should be passed */
-	uint8_t key[BOOT_ENC_KEY_SIZE];
-} bootutil_aes_ctr_context;
-
-void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx);
-
-static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
-{
-    memset(ctx, 0, sizeof(*ctx));
-}
-
-static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
-{
-    memcpy(ctx->key, k, sizeof(ctx->key));
-
-    return 0;
-}
-
-int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter,
-                             const uint8_t *m, uint32_t mlen, size_t blk_off, uint8_t *c);
-int bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter,
-                             const uint8_t *c, uint32_t clen, size_t blk_off, uint8_t *m);
-#endif
-
-#if defined(MCUBOOT_USE_MBED_TLS)
-typedef mbedtls_aes_context bootutil_aes_ctr_context;
-static inline void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
-{
-    (void)mbedtls_aes_init(ctx);
-}
-
-static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
-{
-    mbedtls_aes_free(ctx);
-}
-
-static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
-{
-    return mbedtls_aes_setkey_enc(ctx, k, BOOT_ENC_KEY_SIZE * 8);
-}
-
-static inline int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *m, uint32_t mlen, size_t blk_off, uint8_t *c)
-{
-    uint8_t stream_block[BOOT_ENC_BLOCK_SIZE];
-    return mbedtls_aes_crypt_ctr(ctx, mlen, &blk_off, counter, stream_block, m, c);
-}
-
-static inline int bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *c, uint32_t clen, size_t blk_off, uint8_t *m)
-{
-    uint8_t stream_block[BOOT_ENC_BLOCK_SIZE];
-    return mbedtls_aes_crypt_ctr(ctx, clen, &blk_off, counter, stream_block, c, m);
-}
-#endif /* MCUBOOT_USE_MBED_TLS */
-
-#if defined(MCUBOOT_USE_TINYCRYPT)
-typedef struct tc_aes_key_sched_struct bootutil_aes_ctr_context;
-static inline void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
-{
-    (void)ctx;
-}
-
-static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
-{
-    (void)ctx;
-}
-
-static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
-{
-    int rc;
-    rc = tc_aes128_set_encrypt_key(ctx, k);
-    if (rc != TC_CRYPTO_SUCCESS) {
-        return -1;
-    }
-    return 0;
-}
-
-static int _bootutil_aes_ctr_crypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *in, uint32_t inlen, uint32_t blk_off, uint8_t *out)
-{
-    int rc;
-    rc = tc_ctr_mode(out, inlen, in, inlen, counter, &blk_off, ctx);
-    if (rc != TC_CRYPTO_SUCCESS) {
-        return -1;
-    }
-    return 0;
-}
-
-static inline int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *m, uint32_t mlen, uint32_t blk_off, uint8_t *c)
-{
-    return _bootutil_aes_ctr_crypt(ctx, counter, m, mlen, blk_off, c);
-}
-
-static inline int bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *c, uint32_t clen, uint32_t blk_off, uint8_t *m)
-{
-    return _bootutil_aes_ctr_crypt(ctx, counter, c, clen, blk_off, m);
-}
-#endif /* MCUBOOT_USE_TINYCRYPT */
-
-#ifdef __cplusplus
-}
+    #include "bootutil/crypto/aes_ctr_psa.h"
 #endif
 
 #endif /* __BOOTUTIL_CRYPTO_AES_CTR_H_ */

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr_mbedtls.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr_mbedtls.h
@@ -1,0 +1,58 @@
+/*
+ * This module provides a thin abstraction over some of the crypto
+ * primitives to make it easier to swap out the used crypto library.
+ *
+ * At this point, there are two choices: MCUBOOT_USE_MBED_TLS, or
+ * MCUBOOT_USE_TINYCRYPT.  It is a compile error there is not exactly
+ * one of these defined.
+ */
+
+#ifndef __BOOTUTIL_CRYPTO_AES_CTR_MBEDTLS_H_
+#define __BOOTUTIL_CRYPTO_AES_CTR_MBEDTLS_H_
+
+#include <string.h>
+#include <stdint.h>
+#include "mcuboot_config/mcuboot_config.h"
+#include "bootutil/enc_key_public.h"
+#include <mbedtls/aes.h>
+
+#define BOOT_ENC_BLOCK_SIZE (16)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef mbedtls_aes_context bootutil_aes_ctr_context;
+
+static inline void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
+{
+    (void)mbedtls_aes_init(ctx);
+}
+
+static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
+{
+    mbedtls_aes_free(ctx);
+}
+
+static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
+{
+    return mbedtls_aes_setkey_enc(ctx, k, BOOT_ENC_KEY_SIZE * 8);
+}
+
+static inline int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *m, uint32_t mlen, size_t blk_off, uint8_t *c)
+{
+    uint8_t stream_block[BOOT_ENC_BLOCK_SIZE];
+    return mbedtls_aes_crypt_ctr(ctx, mlen, &blk_off, counter, stream_block, m, c);
+}
+
+static inline int bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *c, uint32_t clen, size_t blk_off, uint8_t *m)
+{
+    uint8_t stream_block[BOOT_ENC_BLOCK_SIZE];
+    return mbedtls_aes_crypt_ctr(ctx, clen, &blk_off, counter, stream_block, c, m);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOOTUTIL_CRYPTO_AES_CTR_MBEDTLS_H_ */

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr_psa.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr_psa.h
@@ -1,0 +1,53 @@
+/*
+ * This module provides a thin abstraction over some of the crypto
+ * primitives to make it easier to swap out the used crypto library.
+ *
+ * At this point, there are two choices: MCUBOOT_USE_MBED_TLS, or
+ * MCUBOOT_USE_TINYCRYPT.  It is a compile error there is not exactly
+ * one of these defined.
+ */
+
+#ifndef __BOOTUTIL_CRYPTO_AES_CTR_PSA_H_
+#define __BOOTUTIL_CRYPTO_AES_CTR_PSA_H_
+
+#include <string.h>
+#include <stdint.h>
+#include "mcuboot_config/mcuboot_config.h"
+#include "bootutil/enc_key_public.h"
+#include <psa/crypto.h>
+
+#define BOOT_ENC_BLOCK_SIZE (16)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	/* Fixme: This should not be, here, psa_key_id should be passed */
+	uint8_t key[BOOT_ENC_KEY_SIZE];
+} bootutil_aes_ctr_context;
+
+void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx);
+
+static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
+{
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
+{
+    memcpy(ctx->key, k, sizeof(ctx->key));
+
+    return 0;
+}
+
+int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter,
+                             const uint8_t *m, uint32_t mlen, size_t blk_off, uint8_t *c);
+int bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter,
+                             const uint8_t *c, uint32_t clen, size_t blk_off, uint8_t *m);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOOTUTIL_CRYPTO_AES_CTR_H_ */

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr_psa.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr_psa.h
@@ -16,30 +16,18 @@
 #include "bootutil/enc_key_public.h"
 #include <psa/crypto.h>
 
-#define BOOT_ENC_BLOCK_SIZE (16)
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-	/* Fixme: This should not be, here, psa_key_id should be passed */
-	uint8_t key[BOOT_ENC_KEY_SIZE];
+    psa_key_id_t key;
 } bootutil_aes_ctr_context;
 
 void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx);
 
-static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
-{
-    memset(ctx, 0, sizeof(*ctx));
-}
-
-static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
-{
-    memcpy(ctx->key, k, sizeof(ctx->key));
-
-    return 0;
-}
+void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx);
+int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k);
 
 int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter,
                              const uint8_t *m, uint32_t mlen, size_t blk_off, uint8_t *c);

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr_tinycrypt.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr_tinycrypt.h
@@ -1,0 +1,77 @@
+/*
+ * This module provides a thin abstraction over some of the crypto
+ * primitives to make it easier to swap out the used crypto library.
+ *
+ * At this point, there are two choices: MCUBOOT_USE_MBED_TLS, or
+ * MCUBOOT_USE_TINYCRYPT.  It is a compile error there is not exactly
+ * one of these defined.
+ */
+
+#ifndef __BOOTUTIL_CRYPTO_AES_CTR_TINYCRYPT_H_
+#define __BOOTUTIL_CRYPTO_AES_CTR_TINYCRYPT_H_
+
+#include <string.h>
+#include <stdint.h>
+#include "mcuboot_config/mcuboot_config.h"
+#include "bootutil/enc_key_public.h"
+
+#include <tinycrypt/aes.h>
+#include <tinycrypt/ctr_mode.h>
+#include <tinycrypt/constants.h>
+
+#if defined(MCUBOOT_AES_256) || (BOOT_ENC_KEY_SIZE != TC_AES_KEY_SIZE)
+    #error "Cannot use AES-256 for encryption with Tinycrypt library."
+#endif
+
+#define BOOT_ENC_BLOCK_SIZE TC_AES_BLOCK_SIZE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct tc_aes_key_sched_struct bootutil_aes_ctr_context;
+static inline void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
+{
+    (void)ctx;
+}
+
+static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
+{
+    (void)ctx;
+}
+
+static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
+{
+    int rc;
+    rc = tc_aes128_set_encrypt_key(ctx, k);
+    if (rc != TC_CRYPTO_SUCCESS) {
+        return -1;
+    }
+    return 0;
+}
+
+static int common_bootutil_aes_ctr_crypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *in, uint32_t inlen, uint32_t blk_off, uint8_t *out)
+{
+    int rc;
+    rc = tc_ctr_mode(out, inlen, in, inlen, counter, &blk_off, ctx);
+    if (rc != TC_CRYPTO_SUCCESS) {
+        return -1;
+    }
+    return 0;
+}
+
+static inline int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *m, uint32_t mlen, uint32_t blk_off, uint8_t *c)
+{
+    return common_bootutil_aes_ctr_crypt(ctx, counter, m, mlen, blk_off, c);
+}
+
+static inline int bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *c, uint32_t clen, uint32_t blk_off, uint8_t *m)
+{
+    return common_bootutil_aes_ctr_crypt(ctx, counter, c, clen, blk_off, m);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOOTUTIL_CRYPTO_AES_CTR_TINYCRYPT_H_ */


### PR DESCRIPTION
Two commits from upstream:
 - split of encryption headers
 - change in encryption context, where there is no longer raw key stored in encryption context, instead context setup function has been setup to import key into PSA and obtain psa_key_id_t key id for it that is then stored in context; all encryption functions will now operate on that key_id, when using the context.

Replacement of raw key array in encryption context, with psa_key_id_t, has reduced MCUboot binary size by ~224 bytes, for non-KMU and non-log-dbg build; small amount of RAM is saved also.