### PR TITLE
[nrf noup] boot: zephyr: cleanup of SPIM for nRF91

### DIFF
--- a/boot/zephyr/include/nrf_cleanup.h
+++ b/boot/zephyr/include/nrf_cleanup.h
@@ -11,8 +11,8 @@
  * Perform cleanup on some peripheral resources used by MCUBoot prior chainload
  * the application.
  *
- * This function disables all RTC instances and UARTE instances.
- * It Disables their interrupts signals as well.
+ * This function disables all RTC, UARTE, and SPIM instances.
+ * It disables their interrupts signals as well.
  */
 void nrf_cleanup_peripheral(void);
 

--- a/boot/zephyr/nrf_cleanup.c
+++ b/boot/zephyr/nrf_cleanup.c
@@ -26,7 +26,9 @@
     #include <hal/nrf_vpr.h>
     #include <softperipheral_regif.h>
 #endif
-
+#if defined(SPIM_PRESENT)
+    #include <hal/nrf_spim.h>
+#endif
 
 #include <string.h>
 
@@ -197,6 +199,33 @@ void nrf_cleanup_peripheral(void)
         memset((uint8_t *)current + NRF_UARTE_PUBLISH_CONF_OFFS, 0,
                NRF_UARTE_PUBLISH_CONF_SIZE);
 #endif
+    }
+#endif
+
+#if defined(SPIM_PRESENT)
+    /* Stop SPIM EasyDMA and disable all instances to prevent stale DMA
+     * from causing RAMACCERR when TF-M reconfigures SPU permissions. */
+    {
+        NRF_SPIM_Type *spim_inst[] = {
+#if defined(NRF_SPIM0)
+            NRF_SPIM0,
+#endif
+#if defined(NRF_SPIM1)
+            NRF_SPIM1,
+#endif
+#if defined(NRF_SPIM2)
+            NRF_SPIM2,
+#endif
+#if defined(NRF_SPIM3)
+            NRF_SPIM3,
+#endif
+        };
+
+        for (int i = 0; i < sizeof(spim_inst) / sizeof(spim_inst[0]); ++i) {
+            nrf_spim_task_trigger(spim_inst[i], NRF_SPIM_TASK_STOP);
+            nrf_spim_disable(spim_inst[i]);
+            nrf_spim_int_disable(spim_inst[i], 0xFFFFFFFF);
+        }
     }
 #endif
 

--- a/docs/release-notes.d/spim-cleanup.md
+++ b/docs/release-notes.d/spim-cleanup.md
@@ -1,0 +1,2 @@
+ - Added SPIM peripheral cleanup in nrf_cleanup to prevent RAMACCERR when
+   TF-M reconfigures SPU SRAM permissions after MCUboot uses SPI flash.


### PR DESCRIPTION
## Summary

- Stop SPIM EasyDMA and disable all instances in `nrf_cleanup_peripheral()` before chain-loading the application
- On nRF91 with TF-M and external SPI flash, MCUboot leaves SPIM active after reading the secondary slot. When TF-M reconfigures SPU SRAM permissions, the stale DMA triggers RAMACCERR

This follows the same pattern as PR #602 (SQSPI cleanup for nRF54L) and the existing UARTE/RTC cleanup code.

## Test plan

- Tested on custom nRF9151 board with external SPI flash (MCUboot secondary slot)
- MCUboot + TF-M + non-secure application boots cleanly with this patch
- Without it, SPU fires RAMACCERR on every boot

## Context

`nrf_cleanup.c` handles peripheral teardown for peripherals that Zephyr cannot deinitialize. SPIM was missing from the cleanup list, which is a problem for any nRF91 board that uses SPI flash for the MCUboot secondary slot.