### PR TITLE
bootutil: Add LCS handling

### DIFF
--- a/boot/bootutil/src/ed25519_psa_kmu_its.c
+++ b/boot/bootutil/src/ed25519_psa_kmu_its.c
@@ -17,6 +17,9 @@
 #if defined(CONFIG_BOOT_SIGNATURE_USING_KMU)
 #include <cracen_psa_kmu.h>
 #endif
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
 
 BOOT_LOG_MODULE_REGISTER(ed25519_psa_kmu_its);
 
@@ -35,6 +38,17 @@ static psa_key_id_t key_ids[] =  {
     MAKE_PSA_KMU_KEY_ID(PSA_KEY_STARTING_ID + PSA_KEY_INDEX_SIZE),
     MAKE_PSA_KMU_KEY_ID(PSA_KEY_STARTING_ID + (2 * PSA_KEY_INDEX_SIZE))
 };
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+BUILD_ASSERT((CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER <
+              PSA_KEY_STARTING_ID) ||
+                 (CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER >
+                  (PSA_KEY_STARTING_ID + (2 * PSA_KEY_INDEX_SIZE))),
+             "Manufacturing application key identifier must not be within the "
+             "application KMU key ID range");
+
+static psa_key_id_t manufacturing_app_key_id =
+    MAKE_PSA_KMU_KEY_ID(CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER);
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
 #define KEY_SLOTS_COUNT CONFIG_BOOT_SIGNATURE_KMU_SLOTS
 
@@ -55,6 +69,10 @@ static const psa_key_id_t key_ids[] =  {
     0x40022102,
     0x40022103
 };
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+static const psa_key_id_t manufacturing_app_key_id =
+    CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER;
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
 #define KEY_SLOTS_COUNT ARRAY_SIZE(key_ids)
 #endif
@@ -77,23 +95,38 @@ int ED25519_verify(const uint8_t *message, size_t message_len,
     status = PSA_ERROR_BAD_STATE;
     BOOT_LOG_DBG("ED25519_verify: total key count %d", KEY_SLOTS_COUNT);
 
-    for (int i = 0; i < KEY_SLOTS_COUNT; ++i) {
-        psa_key_id_t kid = key_ids[i];
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    if (nrf_lcs_get() == NRF_LCS_SECURED) {
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
+        for (int i = 0; i < KEY_SLOTS_COUNT; ++i) {
+            psa_key_id_t kid = key_ids[i];
 
-        BOOT_LOG_DBG("ED25519_verify: trying key ID 0x%" PRIx32, (uint32_t)kid);
-        status = psa_verify_message(kid, PSA_ALG_PURE_EDDSA, message,
-                                    message_len, signature,
-                                    EDDSA_SIGNAGURE_LENGTH);
-        if (status == PSA_SUCCESS) {
+            status = psa_verify_message(kid, PSA_ALG_PURE_EDDSA, message,
+                                        message_len, signature,
+                                        EDDSA_SIGNAGURE_LENGTH);
+            if (status == PSA_SUCCESS) {
 #if defined(CONFIG_BOOT_KMU_KEYS_REVOCATION)
-            if(i < validated_with) {
-                validated_with = i;
-            }
+                if(i < validated_with) {
+                    validated_with = i;
+                }
 #endif
-            return 1;
+                return 1;
+            }
         }
-
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    } else {
+            BOOT_LOG_INF("ED25519_verify: trying manufacturing application key ID 0x%" PRIx32,
+                (uint32_t)manufacturing_app_key_id);
+            /* Do not revoke application keys - pretend as if the first generation key was used */
+            validated_with = 0;
+            status = psa_verify_message(manufacturing_app_key_id, PSA_ALG_PURE_EDDSA, message,
+                                        message_len, signature,
+                                        EDDSA_SIGNAGURE_LENGTH);
+            if (status == PSA_SUCCESS) {
+                return 1;
+            }
     }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
     BOOT_LOG_ERR("ED25519 signature verification failed %d", status);
 

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -13,6 +13,10 @@
 #include <inttypes.h>
 #include <string.h>
 
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
+
 #if defined(MCUBOOT_ENCRYPT_RSA)
 #define BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED
 #include "bootutil/crypto/rsa.h"
@@ -585,6 +589,16 @@ boot_enc_load(struct boot_loader_state *state, int slot,
     int rc;
 
     BOOT_LOG_DBG("boot_enc_load: slot %d", slot);
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    switch (nrf_lcs_get()) {
+    case NRF_LCS_SECURED:
+        break;
+    default:
+        /* The device is in a non-secured state. Avoid loading any encryption key. */
+        return -1;
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
     /* Already loaded... */
     if (boot_enc_valid(enc_state)) {

--- a/boot/bootutil/src/image_ecdsa.c
+++ b/boot/bootutil/src/image_ecdsa.c
@@ -37,6 +37,9 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #include "bootutil_priv.h"
 #include "bootutil/fault_injection_hardening.h"
 #include "bootutil/crypto/ecdsa.h"
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
 
 #if !defined(MCUBOOT_BUILTIN_KEY)
 fih_ret
@@ -48,6 +51,16 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     FIH_DECLARE(fih_rc, FIH_FAILURE);
     uint8_t *pubkey;
     uint8_t *end;
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    if (nrf_lcs_get() != NRF_LCS_SECURED) {
+        if (key_id != CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER) {
+            BOOT_LOG_ERR("bootutil_verify_sig: invalid key ID %d for non-secured device", key_id);
+            FIH_RET(FIH_FAILURE);
+        }
+        BOOT_LOG_DBG("bootutil_verify_sig: using manufacturing application key ID %d", key_id);
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
     BOOT_LOG_DBG("bootutil_verify_sig: ECDSA builtin key %d", key_id);
 
@@ -79,6 +92,16 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     int rc;
     bootutil_ecdsa_context ctx;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    if (nrf_lcs_get() != NRF_LCS_SECURED) {
+        if (key_id != CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER) {
+            BOOT_LOG_ERR("bootutil_verify_sig: invalid key ID %d for non-secured device", key_id);
+            FIH_RET(FIH_FAILURE);
+        }
+        BOOT_LOG_DBG("bootutil_verify_sig: using manufacturing application key ID %d", key_id);
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
     BOOT_LOG_DBG("bootutil_verify_sig: ECDSA embedded key %hhd", key_id);
 

--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -12,6 +12,9 @@
 
 #ifdef MCUBOOT_SIGN_ED25519
 #include "bootutil/sign_key.h"
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
 
 #if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
 /* We are not really using the MBEDTLS but need the ASN.1 parsing functions */
@@ -109,6 +112,17 @@ bootutil_verify(uint8_t *buf, uint32_t blen,
     }
 
 #if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS)
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    if (nrf_lcs_get() != NRF_LCS_SECURED) {
+        if (key_id != CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER) {
+            BOOT_LOG_ERR("bootutil_verify: invalid key ID %d for non-secured device", key_id);
+            FIH_SET(fih_rc, FIH_FAILURE);
+            goto out;
+        }
+        BOOT_LOG_DBG("bootutil_verify: using manufacturing application key ID %d", key_id);
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
+
     pubkey = (uint8_t *)bootutil_keys[key_id].key;
     end = pubkey + *bootutil_keys[key_id].len;
 

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -36,6 +36,9 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #include "bootutil_priv.h"
 #include "bootutil/sign_key.h"
 #include "bootutil/fault_injection_hardening.h"
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
 
 #define BOOTUTIL_CRYPTO_RSA_SIGN_ENABLED
 #include "bootutil/crypto/rsa.h"
@@ -269,6 +272,16 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     FIH_DECLARE(fih_rc, FIH_FAILURE);
     uint8_t *cp;
     uint8_t *end;
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    if (nrf_lcs_get() != NRF_LCS_SECURED) {
+        if (key_id != CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER) {
+            BOOT_LOG_ERR("bootutil_verify_sig: invalid key ID %d for non-secured device", key_id);
+            FIH_RET(FIH_FAILURE);
+        }
+        BOOT_LOG_DBG("bootutil_verify_sig: using manufacturing application key ID %d", key_id);
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
     BOOT_LOG_DBG("bootutil_verify_sig: RSA key_id %d", key_id);
 

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -59,6 +59,10 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #include <compression/decompression.h>
 #endif
 
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
+
 #ifdef MCUBOOT_ENC_IMAGES
 #include "bootutil/enc_key.h"
 #endif
@@ -526,6 +530,14 @@ bootutil_img_validate(struct boot_loader_state *state,
                 rc = -1;
                 goto out;
             }
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+            if (nrf_lcs_get() == NRF_LCS_ASSEMBLY_AND_TEST) {
+                BOOT_LOG_WRN("bootutil_img_validate: device in A&T, skipping key validation");
+                break;
+            }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
+
 #ifndef MCUBOOT_HW_KEY
             rc = LOAD_IMAGE_DATA(hdr, fap, off, buf, len);
             if (rc) {
@@ -551,6 +563,13 @@ bootutil_img_validate(struct boot_loader_state *state,
         case EXPECTED_SIG_TLV:
         {
             BOOT_LOG_DBG("bootutil_img_validate: EXPECTED_SIG_TLV == %d", EXPECTED_SIG_TLV);
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+            if (nrf_lcs_get() == NRF_LCS_ASSEMBLY_AND_TEST) {
+                BOOT_LOG_WRN("bootutil_img_validate: device in A&T, skipping signature verification");
+                FIH_SET(valid_signature, FIH_SUCCESS);
+                break;
+            }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 #if !defined(CONFIG_BOOT_SIGNATURE_USING_KMU) && !defined(CONFIG_NCS_BOOT_SIGNATURE_USING_ITS)
             /* Ignore this signature if it is out of bounds. */
             if (key_id < 0 || key_id >= bootutil_key_cnt) {
@@ -877,6 +896,12 @@ skip_security_counter_check:
         }
 
         while (true) {
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+            if (nrf_lcs_get() == NRF_LCS_ASSEMBLY_AND_TEST) {
+                BOOT_LOG_WRN("bootutil_img_validate: device in A&T, skipping key search");
+                break;
+            }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
             rc = bootutil_tlv_iter_next(&it, &off, &len, &type);
             if (rc < 0) {
                 goto out;
@@ -924,6 +949,12 @@ skip_security_counter_check:
         }
 
         while (true) {
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+            if (nrf_lcs_get() == NRF_LCS_ASSEMBLY_AND_TEST) {
+                BOOT_LOG_WRN("bootutil_img_validate: device in A&T, skipping signature search");
+                break;
+            }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
             rc = bootutil_tlv_iter_next(&it, &off, &len, &type);
             if (rc < 0) {
                 goto out;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -50,6 +50,9 @@
 #include "bootutil/boot_hooks.h"
 #include "bootutil/mcuboot_status.h"
 #include "bootutil_loader.h"
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
 
 #ifndef MCUBOOT_MANIFEST_UPDATES
 
@@ -1986,6 +1989,11 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
 
             /* Swap has finished set to NONE */
             BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_NONE;
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+        } else if (nrf_lcs_get() != NRF_LCS_SECURED) {
+            /* Execute the regular update/swap logic only in the secured state. */
+            BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_NONE;
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
         } else {
             /* There was no partial swap, determine swap type. */
             if (bs->swap_type == BOOT_SWAP_TYPE_NONE) {
@@ -2686,6 +2694,37 @@ boot_select_or_erase(struct boot_loader_state *state)
     memset(active_swap_state, 0, sizeof(struct boot_swap_state));
     rc = boot_read_swap_state(fap, active_swap_state);
     assert(rc == 0);
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    switch (nrf_lcs_get()) {
+    case NRF_LCS_ASSEMBLY_AND_TEST:
+    case NRF_LCS_PSA_ROT_PROVISIONING:
+    {
+        /*
+         * The FW update logic is allowed only in the secured state.
+         * Avoid booting or marking any image that is not already confirmed.
+         */
+        if (active_swap_state->magic == BOOT_MAGIC_GOOD &&
+            active_swap_state->copy_done == BOOT_FLAG_SET &&
+            active_swap_state->image_ok == BOOT_FLAG_SET) {
+            BOOT_LOG_INF("Selecting provisioning image from the %s slot",
+                         (active_slot == BOOT_SLOT_PRIMARY) ?
+                         "primary" : "secondary");
+            return 0;
+        }
+
+        return -1;
+    }
+
+    case NRF_LCS_SECURED:
+        /* Execute the regular logic in the secured state. */
+        break;
+
+    default:
+        /* The device is in a non-secured state. Avoid booting or marking any image. */
+        return -1;
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
     if (active_swap_state->magic != BOOT_MAGIC_GOOD ||
         (active_swap_state->copy_done == BOOT_FLAG_SET &&

--- a/boot/bootutil/src/loader_manifest_xip.c
+++ b/boot/bootutil/src/loader_manifest_xip.c
@@ -48,6 +48,9 @@
 #include "bootutil/fault_injection_hardening.h"
 #include "bootutil/boot_hooks.h"
 #include "bootutil_loader.h"
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
 
 #if defined(MCUBOOT_MANIFEST_UPDATES) && defined(MCUBOOT_DIRECT_XIP)
 #include "bootutil/mcuboot_manifest.h"
@@ -357,6 +360,37 @@ boot_select_or_erase(struct boot_loader_state *state)
         /* Image was not selected for test. Skip slot. */
         return -1;
     }
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    switch (nrf_lcs_get()) {
+    case NRF_LCS_ASSEMBLY_AND_TEST:
+    case NRF_LCS_PSA_ROT_PROVISIONING:
+    {
+        /*
+         * The FW update logic is allowed only in the secured state.
+         * Avoid booting or marking any image that is not already confirmed.
+         */
+        if (active_swap_state->magic == BOOT_MAGIC_GOOD &&
+            active_swap_state->copy_done == BOOT_FLAG_SET &&
+            active_swap_state->image_ok == BOOT_FLAG_SET) {
+            BOOT_LOG_INF("Selecting provisioning image from the %s slot",
+                         (active_slot == BOOT_SLOT_PRIMARY) ?
+                         "primary" : "secondary");
+            return 0;
+        }
+
+        return -1;
+    }
+
+    case NRF_LCS_SECURED:
+        /* Execute the regular logic in the secured state. */
+        break;
+
+    default:
+        /* The device is in a non-secured state. Avoid booting or marking any image. */
+        return -1;
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
     if (active_swap_state->copy_done == BOOT_FLAG_SET &&
         active_swap_state->image_ok  != BOOT_FLAG_SET) {

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1532,4 +1532,20 @@ config PM_APP_ALIGNMENT
 	default 0x1000 if SOC_SERIES_NRF54L
 	default FPROTECT_BLOCK_SIZE
 
+config NCS_MCUBOOT_LCS_AWARE
+	bool "Lifecycle state awareness"
+	depends on NRF_LCS && (MCUBOOT_MCUBOOT_IMAGE_NUMBER != -1)
+	default y
+	help
+	  If y, the bootloader will be aware of the device lifecycle state and
+	  will only boot and update images in matching lifecycle states.
+
+config NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER
+	int "Manufacturing application key identifier"
+	depends on NCS_MCUBOOT_LCS_AWARE
+	default 224 if BOOT_SIGNATURE_USING_KMU
+	default 0
+	help
+	  Manufacturing application key identifier.
+
 source "Kconfig.zephyr"

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -59,6 +59,10 @@
 #include "boot_serial/boot_serial_cdc_acm_usb_next.h"
 #endif
 
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
+
 #if defined(CONFIG_MCUBOOT_UUID_VID) || defined(CONFIG_MCUBOOT_UUID_CID)
 #include "bootutil/mcuboot_uuid.h"
 #endif /* CONFIG_MCUBOOT_UUID_VID || CONFIG_MCUBOOT_UUID_CID */
@@ -786,6 +790,26 @@ int main(void)
     if (rc) {
         BOOT_LOG_ERR("Failed to prevalidate the state: %d", rc);
     }
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    BOOT_LOG_INF("LCS-awareness enabled. Current LCS: %x", nrf_lcs_get());
+
+    switch (nrf_lcs_get()) {
+    case NRF_LCS_ASSEMBLY_AND_TEST:
+    case NRF_LCS_PSA_ROT_PROVISIONING:
+    case NRF_LCS_SECURED:
+        /* Boot and update logic is allowed only in these three states. */
+        break;
+
+    default:
+        BOOT_LOG_ERR("Device in an unbootable state: %x", nrf_lcs_get());
+        mcuboot_status_change(MCUBOOT_STATUS_BOOT_FAILED);
+        FIH_PANIC;
+        return -1;
+    }
+#else
+    BOOT_LOG_INF("LCS-awareness disabled, skipping LCS check");
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
 
 #ifdef CONFIG_BOOT_SERIAL_ENTRANCE_GPIO
     BOOT_LOG_DBG("Checking GPIO for serial recovery");


### PR DESCRIPTION
Add logic that interprets the LCS value and changes the internal boot logic, allowing to implement a provisioning application.

Ref: NCSDK-37035