### PR TITLE
[nrf noup] bootutil: Change KMU KConfig option

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -426,7 +426,7 @@ config BOOT_BYPASS_KEY_MATCH
 config BOOT_SIGNATURE_USING_KMU
 	bool "Use KMU stored keys for signature verification"
 	depends on PSA_CRYPTO
-	depends on CRACEN_LIB_KMU
+	depends on CRACEN_KMU
 	select PSA_WANT_ALG_GCM
 	select PSA_WANT_KEY_TYPE_AES
 	select PSA_WANT_AES_KEY_SIZE_256


### PR DESCRIPTION
CRACEN_LIB_KMU exchanged with CRACEN_KMU KConfig option since NRFX driver is now used instead of LIB_KMU.

manifest-pr-skip

test_sdk_mcuboot: PR-156