### PR TITLE
[Backport ncs-v3.3-branch] boot: zephyr: Fix uuid + extflash on nRF54H20

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -20,21 +20,41 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
+#if (DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)))
+#define EXT_FLASH_DEVICE_NODE DT_INST(0, jedec_spi_nor)
+#if defined(CONFIG_SPI_NOR)
+#define EXT_FLASH_DEVICE DEVICE_DT_GET(EXT_FLASH_DEVICE_NODE)
+#endif
+#define EXT_FLASH_DEVICE_ID SPI_FLASH_0_ID
+#define EXT_FLASH_DEVICE_BASE 0
+
+#elif (DT_NODE_EXISTS(DT_INST(0, jedec_mspi_nor)))
+#define EXT_FLASH_DEVICE_NODE DT_INST(0, jedec_mspi_nor)
+#if defined(CONFIG_FLASH_MSPI_NOR)
+#define EXT_FLASH_DEVICE DEVICE_DT_GET(EXT_FLASH_DEVICE_NODE)
+#endif
+#define EXT_FLASH_DEVICE_ID SPI_FLASH_0_ID
+#define EXT_FLASH_DEVICE_BASE 0
+#endif
+
 #if (DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
 #define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
-
-#elif (DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)))
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#define FLASH_DEVICE_BASE 0
-#define FLASH_DEVICE_NODE DT_INST(0, jedec_spi_nor)
 
 #elif (defined(CONFIG_SOC_SERIES_NRF54H) && DT_HAS_CHOSEN(zephyr_flash))
 
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
 #define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash)
+
+#elif defined(EXT_FLASH_DEVICE_ID)
+/* This code is here for backwards compatibility.
+ * Probably it was added to support devices fully running from external flash.
+ */
+#define FLASH_DEVICE_ID EXT_FLASH_DEVICE_ID
+#define FLASH_DEVICE_BASE EXT_FLASH_DEVICE_BASE
+#define FLASH_DEVICE_NODE EXT_FLASH_DEVICE_NODE
 
 #else
 #error "FLASH_DEVICE_ID could not be determined"
@@ -44,6 +64,12 @@ static const struct device *flash_dev = DEVICE_DT_GET(FLASH_DEVICE_NODE);
 
 int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 {
+#if defined(EXT_FLASH_DEVICE)
+    if (fd_id == EXT_FLASH_DEVICE_ID) {
+        *ret = EXT_FLASH_DEVICE_BASE;
+        return 0;
+    }
+#endif
     if (fd_id != FLASH_DEVICE_ID) {
         BOOT_LOG_ERR("invalid flash ID %d; expected %d",
                      fd_id, FLASH_DEVICE_ID);
@@ -149,7 +175,14 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa)
 {
+#if defined(EXT_FLASH_DEVICE)
+    if (fa->fa_dev == EXT_FLASH_DEVICE) {
+        return EXT_FLASH_DEVICE_ID;
+    }
+#else
     (void)fa;
+#endif
+
     return FLASH_DEVICE_ID;
 }
 

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -20,45 +20,15 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
-#if defined(CONFIG_STM32_MEMMAP)
-/* MEMORY MAPPED for XiP on external NOR flash takes the sspi-nor or ospi-nor or qspi-nor device */
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#if DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_xspi_nor), okay)
-#define DT_DRV_COMPAT st_stm32_xspi_nor
-#define FLASH_DEVICE_NODE DT_INST(0, st_stm32_xspi_nor)
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
-#elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_ospi_nor), okay)
-#define DT_DRV_COMPAT st_stm32_ospi_nor
-#define FLASH_DEVICE_NODE DT_INST(0, st_stm32_ospi_nor)
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
-#elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_qspi_nor), okay)
-#define DT_DRV_COMPAT st_stm32_qspi_nor
-#define FLASH_DEVICE_NODE DT_INST(0, st_stm32_qspi_nor)
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
-#else
-#error "FLASH_DEVICE_NODE could not be determined"
-#endif
-
-#elif (DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_imx_flexspi)) && DT_HAS_CHOSEN(zephyr_flash_controller))
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(FLASH_DEVICE_NODE), 1)
-
-#elif (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
+#if (DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
 #define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
 
-#elif (defined(CONFIG_XTENSA) && DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)))
+#elif (DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)))
 #define FLASH_DEVICE_ID SPI_FLASH_0_ID
 #define FLASH_DEVICE_BASE 0
 #define FLASH_DEVICE_NODE DT_INST(0, jedec_spi_nor)
-
-#elif defined(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32)
-
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#define FLASH_DEVICE_BASE 0
-#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
 
 #elif (defined(CONFIG_SOC_SERIES_NRF54H) && DT_HAS_CHOSEN(zephyr_flash))
 

--- a/boot/zephyr/uuid/uuid.c
+++ b/boot/zephyr/uuid/uuid.c
@@ -37,7 +37,7 @@ fih_ret boot_uuid_vid_match(const struct flash_area *fap, const struct image_uui
 	 */
 	fa_ret = flash_device_base(flash_area_get_device_id(fap), &base);
 	if (fa_ret != 0) {
-		base = 0;
+		FIH_RET(FIH_FAILURE);
 	}
 
 	for (size_t i = 0; i < n_uuids; i++) {
@@ -68,7 +68,7 @@ fih_ret boot_uuid_cid_match(const struct flash_area *fap, const struct image_uui
 	 */
 	fa_ret = flash_device_base(flash_area_get_device_id(fap), &base);
 	if (fa_ret != 0) {
-		base = 0;
+		FIH_RET(FIH_FAILURE);
 	}
 
 	for (size_t i = 0; i < n_uuids; i++) {


### PR DESCRIPTION
Backport 0537714e5dd2aee9f81d3ac842d570e36aaa2f11~2..0537714e5dd2aee9f81d3ac842d570e36aaa2f11 from #635.