### PR TITLE
[nrf noup] boot: zephyr: Support 4 images with MPCCONF write protection

### DIFF
--- a/boot/zephyr/load_ironside_se_conf_mpc.c
+++ b/boot/zephyr/load_ironside_se_conf_mpc.c
@@ -16,41 +16,15 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
-BUILD_ASSERT(MCUBOOT_IMAGE_NUMBER <= 2,
+BUILD_ASSERT(MCUBOOT_IMAGE_NUMBER <= 4,
 	     "The MPC override configuration used to provide write protection for the image "
-	     "partitions does not currently support more than two images.");
+	     "partitions does not currently support more than four images.");
 
 /* Required alignment for OVERRIDE addresses in MPC110. */
-#define OVERRIDE_ALIGNMENT KB(4)
-
-/* clang-format off */
-#define MIN_START_ADDR(_label0, _label1)                                                           \
-	MIN(PARTITION_ADDRESS(_label0),                                                    \
-	    COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(_label1)),                            \
-	        (PARTITION_ADDRESS(_label1)),                                              \
-	        (UINTPTR_MAX)))
-
-#define MIN_END_ADDR(_label0, _label1)                                                             \
-	MIN((PARTITION_ADDRESS(_label0) + PARTITION_SIZE(_label0)),                    \
-	    COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(_label1)),                            \
-	        ((PARTITION_ADDRESS(_label1) + PARTITION_SIZE(_label1))),              \
-	        (UINTPTR_MAX)))
-
-#define MAX_START_ADDR(_label0, _label1)                                                           \
-	MAX(PARTITION_ADDRESS(_label0),                                                      \
-	    COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(_label1)),                            \
-	        (PARTITION_ADDRESS(_label1)),                                                \
-	        (0)))
-
-#define MAX_END_ADDR(_label0, _label1)                                                             \
-	MAX((PARTITION_ADDRESS(_label0) + PARTITION_SIZE(_label0)),                    \
-	    COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(_label1)),                            \
-	        ((PARTITION_ADDRESS(_label1) + PARTITION_SIZE(_label1))),              \
-	        (0)))
-/* clang-format on */
+#define OVERRIDE_ALIGNMENT_KB 4
+#define OVERRIDE_ALIGNMENT    KB(OVERRIDE_ALIGNMENT_KB)
 
 #define ACCESSIBLE_MRAM_START PARTITION_NODE_ADDRESS(DT_CHOSEN(zephyr_code_partition))
-BUILD_ASSERT((ACCESSIBLE_MRAM_START % OVERRIDE_ALIGNMENT) == 0);
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(secure_storage_partition))
 BUILD_ASSERT((PARTITION_ADDRESS(secure_storage_partition) +
@@ -64,80 +38,269 @@ BUILD_ASSERT((PARTITION_ADDRESS(secure_storage_partition) +
 #else
 #define ACCESSIBLE_MRAM_END (DT_REG_ADDR(DT_NODELABEL(mram1x)) + DT_REG_SIZE(DT_NODELABEL(mram1x)))
 #endif
-BUILD_ASSERT((ACCESSIBLE_MRAM_END % OVERRIDE_ALIGNMENT) == 0);
 
 #define BOOT_PARTITION_END                                                                         \
-	(PARTITION_NODE_ADDRESS(DT_CHOSEN(zephyr_code_partition)) +                          \
+	(PARTITION_NODE_ADDRESS(DT_CHOSEN(zephyr_code_partition)) +                                \
 	 CONFIG_NCS_MCUBOOT_MPCCONF_STATIC_WRITE_PROTECTION_INITIAL_REGION_SIZE)
-BUILD_ASSERT((BOOT_PARTITION_END % OVERRIDE_ALIGNMENT) == 0);
 
-/* Address ranges of the "active" images when booting slot 0.
- * We define:
- * - "active 0" as the slot 0 image with the lowest address.
- * - "active 1" as the slot 0 image with the highest address (if it exists).
- */
-#define SLOT0_ACTIVE0_START MIN_START_ADDR(slot0_partition, slot2_partition)
-BUILD_ASSERT((SLOT0_ACTIVE0_START % OVERRIDE_ALIGNMENT) == 0);
-
-#define SLOT0_ACTIVE0_END MIN_END_ADDR(slot0_partition, slot2_partition)
-BUILD_ASSERT((SLOT0_ACTIVE0_END % OVERRIDE_ALIGNMENT) == 0);
+/* Partition slot addresses (MCUboot index order, not address-sorted)  */
+#define PRIMARY_P0_START   PARTITION_ADDRESS(slot0_partition)
+#define PRIMARY_P0_END     (PRIMARY_P0_START + PARTITION_SIZE(slot0_partition))
+#define SECONDARY_P0_START PARTITION_ADDRESS(slot1_partition)
+#define SECONDARY_P0_END   (SECONDARY_P0_START + PARTITION_SIZE(slot1_partition))
 
 #if MCUBOOT_IMAGE_NUMBER > 1
-#define SLOT0_ACTIVE1_START MAX_START_ADDR(slot0_partition, slot2_partition)
-BUILD_ASSERT((SLOT0_ACTIVE1_START % OVERRIDE_ALIGNMENT) == 0);
-
-#define SLOT0_ACTIVE1_END MAX_END_ADDR(slot0_partition, slot2_partition)
-BUILD_ASSERT((SLOT0_ACTIVE1_END % OVERRIDE_ALIGNMENT) == 0);
+#define PRIMARY_P1_START   PARTITION_ADDRESS(slot2_partition)
+#define PRIMARY_P1_END     (PRIMARY_P1_START + PARTITION_SIZE(slot2_partition))
+#define SECONDARY_P1_START PARTITION_ADDRESS(slot3_partition)
+#define SECONDARY_P1_END   (SECONDARY_P1_START + PARTITION_SIZE(slot3_partition))
 #endif
 
-/* Address ranges of the "active" images when booting slot 1.
- * We define:
- * - "active 0" as the slot 1 image with the lowest address.
- * - "active 1" as the slot 1 image with the highest address (if it exists).
+#if MCUBOOT_IMAGE_NUMBER > 2
+#define PRIMARY_P2_START   PARTITION_ADDRESS(slot4_partition)
+#define PRIMARY_P2_END     (PRIMARY_P2_START + PARTITION_SIZE(slot4_partition))
+#define SECONDARY_P2_START PARTITION_ADDRESS(slot5_partition)
+#define SECONDARY_P2_END   (SECONDARY_P2_START + PARTITION_SIZE(slot5_partition))
+#endif
+
+#if MCUBOOT_IMAGE_NUMBER > 3
+#define PRIMARY_P3_START   PARTITION_ADDRESS(slot6_partition)
+#define PRIMARY_P3_END     (PRIMARY_P3_START + PARTITION_SIZE(slot6_partition))
+#define SECONDARY_P3_START PARTITION_ADDRESS(slot7_partition)
+#define SECONDARY_P3_END   (SECONDARY_P3_START + PARTITION_SIZE(slot7_partition))
+#endif
+
+/* Median of three values. */
+#define MEDIAN3(a, b, c) MAX(MIN((a), (b)), MIN(MAX((a), (b)), (c)))
+
+/*
+ * Ordering for four distinct values.
+ * SORT4_2ND/3RD require all four inputs to be distinct.
  */
-#define SLOT1_ACTIVE0_START MIN_START_ADDR(slot1_partition, slot3_partition)
-BUILD_ASSERT((SLOT1_ACTIVE0_START % OVERRIDE_ALIGNMENT) == 0);
+#define SORT4_1ST(a, b, c, d) MIN(MIN((a), (b)), MIN((c), (d)))
+#define SORT4_4TH(a, b, c, d) MAX(MAX((a), (b)), MAX((c), (d)))
+#define SORT4_2ND(a, b, c, d)                                                                      \
+	MIN(MIN(MIN(MAX((a), (b)), MAX((a), (c))), MAX((a), (d))),                                 \
+	    MIN(MIN(MAX((b), (c)), MAX((b), (d))), MAX((c), (d))))
+#define SORT4_3RD(a, b, c, d)                                                                      \
+	MAX(MAX(MAX(MIN((a), (b)), MIN((a), (c))), MIN((a), (d))),                                 \
+	    MAX(MAX(MIN((b), (c)), MIN((b), (d))), MIN((c), (d))))
 
-#define SLOT1_ACTIVE0_END MIN_END_ADDR(slot1_partition, slot3_partition)
-BUILD_ASSERT((SLOT1_ACTIVE0_END % OVERRIDE_ALIGNMENT) == 0);
+/*
+ * Map a sorted ACTIVE start back to its partition end. First match wins,
+ * so duplicates from unused-slot aliasing are safe.
+ */
+#define END_FOR_START(s0, e0, s1, e1, s2, e2, s3, e3, key)                                         \
+	(((s0) == (key)) ? (e0) : ((s1) == (key)) ? (e1) : ((s2) == (key)) ? (e2) : (e3))
 
-#if MCUBOOT_IMAGE_NUMBER > 1
-#define SLOT1_ACTIVE1_START MAX_START_ADDR(slot1_partition, slot3_partition)
-BUILD_ASSERT((SLOT1_ACTIVE1_START % OVERRIDE_ALIGNMENT) == 0);
+/*
+ * MCUboot image indices (P0..P3) are not necessarily in address order in MRAM.
+ * The macros below this are used to sort them to be able to add write permissions to the gaps
+ * before, between, or after the partitions.
+ *
+ * When MCUBOOT_IMAGE_NUMBER < 4, unused ACTIVE_* values repeat and the inter-image gaps
+ * have zero size. This is done just to simplify certain parts below, like the BUILD_ASSERTs.
+ */
+#if MCUBOOT_IMAGE_NUMBER == 1
 
-#define SLOT1_ACTIVE1_END MAX_END_ADDR(slot1_partition, slot3_partition)
-BUILD_ASSERT((SLOT1_ACTIVE1_END % OVERRIDE_ALIGNMENT) == 0);
+#define PRIMARY_ACTIVE_0_START PRIMARY_P0_START
+#define PRIMARY_ACTIVE_1_START PRIMARY_P0_START
+#define PRIMARY_ACTIVE_2_START PRIMARY_P0_START
+#define PRIMARY_ACTIVE_3_START PRIMARY_P0_START
+#define PRIMARY_ACTIVE_0_END   PRIMARY_P0_END
+#define PRIMARY_ACTIVE_1_END   PRIMARY_P0_END
+#define PRIMARY_ACTIVE_2_END   PRIMARY_P0_END
+#define PRIMARY_ACTIVE_3_END   PRIMARY_P0_END
+
+#define SECONDARY_ACTIVE_0_START SECONDARY_P0_START
+#define SECONDARY_ACTIVE_1_START SECONDARY_P0_START
+#define SECONDARY_ACTIVE_2_START SECONDARY_P0_START
+#define SECONDARY_ACTIVE_3_START SECONDARY_P0_START
+#define SECONDARY_ACTIVE_0_END   SECONDARY_P0_END
+#define SECONDARY_ACTIVE_1_END   SECONDARY_P0_END
+#define SECONDARY_ACTIVE_2_END   SECONDARY_P0_END
+#define SECONDARY_ACTIVE_3_END   SECONDARY_P0_END
+
+#elif MCUBOOT_IMAGE_NUMBER == 2
+
+#define PRIMARY_ACTIVE_0_START MIN(PRIMARY_P0_START, PRIMARY_P1_START)
+#define PRIMARY_ACTIVE_1_START MAX(PRIMARY_P0_START, PRIMARY_P1_START)
+#define PRIMARY_ACTIVE_2_START PRIMARY_ACTIVE_1_START
+#define PRIMARY_ACTIVE_3_START PRIMARY_ACTIVE_1_START
+#define PRIMARY_ACTIVE_0_END                                                                       \
+	((PRIMARY_P0_START <= PRIMARY_P1_START) ? PRIMARY_P0_END : PRIMARY_P1_END)
+#define PRIMARY_ACTIVE_1_END                                                                       \
+	((PRIMARY_P0_START >= PRIMARY_P1_START) ? PRIMARY_P0_END : PRIMARY_P1_END)
+#define PRIMARY_ACTIVE_2_END PRIMARY_ACTIVE_1_END
+#define PRIMARY_ACTIVE_3_END PRIMARY_ACTIVE_1_END
+
+#define SECONDARY_ACTIVE_0_START MIN(SECONDARY_P0_START, SECONDARY_P1_START)
+#define SECONDARY_ACTIVE_1_START MAX(SECONDARY_P0_START, SECONDARY_P1_START)
+#define SECONDARY_ACTIVE_2_START SECONDARY_ACTIVE_1_START
+#define SECONDARY_ACTIVE_3_START SECONDARY_ACTIVE_1_START
+#define SECONDARY_ACTIVE_0_END                                                                     \
+	((SECONDARY_P0_START <= SECONDARY_P1_START) ? SECONDARY_P0_END : SECONDARY_P1_END)
+#define SECONDARY_ACTIVE_1_END                                                                     \
+	((SECONDARY_P0_START >= SECONDARY_P1_START) ? SECONDARY_P0_END : SECONDARY_P1_END)
+#define SECONDARY_ACTIVE_2_END SECONDARY_ACTIVE_1_END
+#define SECONDARY_ACTIVE_3_END SECONDARY_ACTIVE_1_END
+
+#elif MCUBOOT_IMAGE_NUMBER == 3
+
+#define PRIMARY_ACTIVE_0_START MIN(MIN(PRIMARY_P0_START, PRIMARY_P1_START), PRIMARY_P2_START)
+#define PRIMARY_ACTIVE_1_START MEDIAN3(PRIMARY_P0_START, PRIMARY_P1_START, PRIMARY_P2_START)
+#define PRIMARY_ACTIVE_2_START MAX(MAX(PRIMARY_P0_START, PRIMARY_P1_START), PRIMARY_P2_START)
+#define PRIMARY_ACTIVE_3_START PRIMARY_ACTIVE_2_START
+#define PRIMARY_ACTIVE_0_END                                                                       \
+	END_FOR_START(PRIMARY_P0_START, PRIMARY_P0_END, PRIMARY_P1_START, PRIMARY_P1_END,          \
+		      PRIMARY_P2_START, PRIMARY_P2_END, PRIMARY_P2_START, PRIMARY_P2_END,          \
+		      PRIMARY_ACTIVE_0_START)
+#define PRIMARY_ACTIVE_1_END                                                                       \
+	END_FOR_START(PRIMARY_P0_START, PRIMARY_P0_END, PRIMARY_P1_START, PRIMARY_P1_END,          \
+		      PRIMARY_P2_START, PRIMARY_P2_END, PRIMARY_P2_START, PRIMARY_P2_END,          \
+		      PRIMARY_ACTIVE_1_START)
+#define PRIMARY_ACTIVE_2_END                                                                       \
+	END_FOR_START(PRIMARY_P0_START, PRIMARY_P0_END, PRIMARY_P1_START, PRIMARY_P1_END,          \
+		      PRIMARY_P2_START, PRIMARY_P2_END, PRIMARY_P2_START, PRIMARY_P2_END,          \
+		      PRIMARY_ACTIVE_2_START)
+#define PRIMARY_ACTIVE_3_END PRIMARY_ACTIVE_2_END
+
+#define SECONDARY_ACTIVE_0_START                                                                   \
+	MIN(MIN(SECONDARY_P0_START, SECONDARY_P1_START), SECONDARY_P2_START)
+#define SECONDARY_ACTIVE_1_START MEDIAN3(SECONDARY_P0_START, SECONDARY_P1_START, SECONDARY_P2_START)
+#define SECONDARY_ACTIVE_2_START                                                                   \
+	MAX(MAX(SECONDARY_P0_START, SECONDARY_P1_START), SECONDARY_P2_START)
+#define SECONDARY_ACTIVE_3_START SECONDARY_ACTIVE_2_START
+#define SECONDARY_ACTIVE_0_END                                                                     \
+	END_FOR_START(SECONDARY_P0_START, SECONDARY_P0_END, SECONDARY_P1_START, SECONDARY_P1_END,  \
+		      SECONDARY_P2_START, SECONDARY_P2_END, SECONDARY_P2_START, SECONDARY_P2_END,  \
+		      SECONDARY_ACTIVE_0_START)
+#define SECONDARY_ACTIVE_1_END                                                                     \
+	END_FOR_START(SECONDARY_P0_START, SECONDARY_P0_END, SECONDARY_P1_START, SECONDARY_P1_END,  \
+		      SECONDARY_P2_START, SECONDARY_P2_END, SECONDARY_P2_START, SECONDARY_P2_END,  \
+		      SECONDARY_ACTIVE_1_START)
+#define SECONDARY_ACTIVE_2_END                                                                     \
+	END_FOR_START(SECONDARY_P0_START, SECONDARY_P0_END, SECONDARY_P1_START, SECONDARY_P1_END,  \
+		      SECONDARY_P2_START, SECONDARY_P2_END, SECONDARY_P2_START, SECONDARY_P2_END,  \
+		      SECONDARY_ACTIVE_2_START)
+#define SECONDARY_ACTIVE_3_END SECONDARY_ACTIVE_2_END
+
+#else /* MCUBOOT_IMAGE_NUMBER == 4 */
+
+#define PRIMARY_ACTIVE_0_START                                                                     \
+	SORT4_1ST(PRIMARY_P0_START, PRIMARY_P1_START, PRIMARY_P2_START, PRIMARY_P3_START)
+#define PRIMARY_ACTIVE_1_START                                                                     \
+	SORT4_2ND(PRIMARY_P0_START, PRIMARY_P1_START, PRIMARY_P2_START, PRIMARY_P3_START)
+#define PRIMARY_ACTIVE_2_START                                                                     \
+	SORT4_3RD(PRIMARY_P0_START, PRIMARY_P1_START, PRIMARY_P2_START, PRIMARY_P3_START)
+#define PRIMARY_ACTIVE_3_START                                                                     \
+	SORT4_4TH(PRIMARY_P0_START, PRIMARY_P1_START, PRIMARY_P2_START, PRIMARY_P3_START)
+#define PRIMARY_ACTIVE_0_END                                                                       \
+	END_FOR_START(PRIMARY_P0_START, PRIMARY_P0_END, PRIMARY_P1_START, PRIMARY_P1_END,          \
+		      PRIMARY_P2_START, PRIMARY_P2_END, PRIMARY_P3_START, PRIMARY_P3_END,          \
+		      PRIMARY_ACTIVE_0_START)
+#define PRIMARY_ACTIVE_1_END                                                                       \
+	END_FOR_START(PRIMARY_P0_START, PRIMARY_P0_END, PRIMARY_P1_START, PRIMARY_P1_END,          \
+		      PRIMARY_P2_START, PRIMARY_P2_END, PRIMARY_P3_START, PRIMARY_P3_END,          \
+		      PRIMARY_ACTIVE_1_START)
+#define PRIMARY_ACTIVE_2_END                                                                       \
+	END_FOR_START(PRIMARY_P0_START, PRIMARY_P0_END, PRIMARY_P1_START, PRIMARY_P1_END,          \
+		      PRIMARY_P2_START, PRIMARY_P2_END, PRIMARY_P3_START, PRIMARY_P3_END,          \
+		      PRIMARY_ACTIVE_2_START)
+#define PRIMARY_ACTIVE_3_END                                                                       \
+	END_FOR_START(PRIMARY_P0_START, PRIMARY_P0_END, PRIMARY_P1_START, PRIMARY_P1_END,          \
+		      PRIMARY_P2_START, PRIMARY_P2_END, PRIMARY_P3_START, PRIMARY_P3_END,          \
+		      PRIMARY_ACTIVE_3_START)
+
+#define SECONDARY_ACTIVE_0_START                                                                   \
+	SORT4_1ST(SECONDARY_P0_START, SECONDARY_P1_START, SECONDARY_P2_START, SECONDARY_P3_START)
+#define SECONDARY_ACTIVE_1_START                                                                   \
+	SORT4_2ND(SECONDARY_P0_START, SECONDARY_P1_START, SECONDARY_P2_START, SECONDARY_P3_START)
+#define SECONDARY_ACTIVE_2_START                                                                   \
+	SORT4_3RD(SECONDARY_P0_START, SECONDARY_P1_START, SECONDARY_P2_START, SECONDARY_P3_START)
+#define SECONDARY_ACTIVE_3_START                                                                   \
+	SORT4_4TH(SECONDARY_P0_START, SECONDARY_P1_START, SECONDARY_P2_START, SECONDARY_P3_START)
+#define SECONDARY_ACTIVE_0_END                                                                     \
+	END_FOR_START(SECONDARY_P0_START, SECONDARY_P0_END, SECONDARY_P1_START, SECONDARY_P1_END,  \
+		      SECONDARY_P2_START, SECONDARY_P2_END, SECONDARY_P3_START, SECONDARY_P3_END,  \
+		      SECONDARY_ACTIVE_0_START)
+#define SECONDARY_ACTIVE_1_END                                                                     \
+	END_FOR_START(SECONDARY_P0_START, SECONDARY_P0_END, SECONDARY_P1_START, SECONDARY_P1_END,  \
+		      SECONDARY_P2_START, SECONDARY_P2_END, SECONDARY_P3_START, SECONDARY_P3_END,  \
+		      SECONDARY_ACTIVE_1_START)
+#define SECONDARY_ACTIVE_2_END                                                                     \
+	END_FOR_START(SECONDARY_P0_START, SECONDARY_P0_END, SECONDARY_P1_START, SECONDARY_P1_END,  \
+		      SECONDARY_P2_START, SECONDARY_P2_END, SECONDARY_P3_START, SECONDARY_P3_END,  \
+		      SECONDARY_ACTIVE_2_START)
+#define SECONDARY_ACTIVE_3_END                                                                     \
+	END_FOR_START(SECONDARY_P0_START, SECONDARY_P0_END, SECONDARY_P1_START, SECONDARY_P1_END,  \
+		      SECONDARY_P2_START, SECONDARY_P2_END, SECONDARY_P3_START, SECONDARY_P3_END,  \
+		      SECONDARY_ACTIVE_3_START)
+
 #endif
+
+#define CHECK_MPC_ADDRESS_ALIGNMENT(_name_str, _addr)                                              \
+	BUILD_ASSERT(((_addr) % OVERRIDE_ALIGNMENT) == 0,                                          \
+		     _name_str " is not aligned to " STRINGIFY(OVERRIDE_ALIGNMENT_KB) "KiB")
+
+CHECK_MPC_ADDRESS_ALIGNMENT("Bootloader partition", ACCESSIBLE_MRAM_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("MRAM end / secure storage", ACCESSIBLE_MRAM_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("Bootloader partition", BOOT_PARTITION_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_0_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_0_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_1_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_1_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_2_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_2_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_3_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one primary image partition", PRIMARY_ACTIVE_3_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_0_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_0_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_1_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_1_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_2_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_2_END);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_3_START);
+CHECK_MPC_ADDRESS_ALIGNMENT("At least one secondary image partition", SECONDARY_ACTIVE_3_END);
 
 /* MPC overrides used to implement image write protection.
  *
  * See the explanations on the various tables below to understand how they are used.
  * The main basis for selecting these is that they all accept OWNERID = None, meaning
  * that we can use them to implement write protection without forcing owner based isolation.
- * Overrides 1 and 2 are those used by IronSide SE to give full RWX access to MRAM in the default
- * configuration - therefore overwriting those overwrites the defaults.
+ * Overrides 1 and 2 are those used by IronSide SE to give full RWX access to MRAM in the
+ * default configuration - therefore overwriting those overwrites the defaults.
  */
 
 /* Override used for assigning R_X perms as a default. */
 #define MPC110_OVERRIDE_DEFAULT_RX (uintptr_t)&NRF_MPC110->OVERRIDE[1]
 
-/* Override used for assigning RWX perms to the range between the first write protected region
- * (bootloader code area by default, but can be extended) to the start of the first active image
- * area.
+/* Override used for assigning RWX perms to the range between the first write protected
+ * region (bootloader code area by default, but can be extended) to the start of the first
+ * active image area.
  */
 #define MPC110_OVERRIDE_INITIAL_END_TO_ACTIVE0_START_RWX (uintptr_t)&NRF_MPC110->OVERRIDE[2]
 
-/* Override used for assigning RWX perms to the range between the end of the first active image
- * area and the start of the second active image area, only used if there are two images in the
- * slot.
+/* Override used for assigning RWX perms between the end of the lower image and the start of
+ * the next image by address (first inter-image gap when MCUBOOT_IMAGE_NUMBER > 1).
  */
 #define MPC110_OVERRIDE_ACTIVE0_END_TO_ACTIVE1_START_RWX (uintptr_t)&NRF_MPC110->OVERRIDE[6]
+
+/* Override used for assigning RWX perms between the end of the middle image and the start
+ * of the next image by address (second inter-image gap when MCUBOOT_IMAGE_NUMBER > 2).
+ */
+#define MPC110_OVERRIDE_ACTIVE1_END_TO_ACTIVE2_START_RWX (uintptr_t)&NRF_MPC110->OVERRIDE[7]
+
+/* Override used for assigning RWX perms between the end of the third image by address and the
+ * start of the fourth (third inter-image gap when MCUBOOT_IMAGE_NUMBER > 3).
+ */
+#define MPC110_OVERRIDE_ACTIVE2_END_TO_ACTIVE3_START_RWX (uintptr_t)&NRF_MPC110->OVERRIDE[10]
 
 /* Override used for assigning RWX perms to the range between the end of the last active
  * image area and the end of the available MRAM.
  */
 #define MPC110_OVERRIDE_LAST_ACTIVE_END_TO_ACCESSIBLE_MRAM_END_RWX                                 \
-	(uintptr_t)&NRF_MPC110->OVERRIDE[7]
+	(uintptr_t)&NRF_MPC110->OVERRIDE[11]
 
 /* Default masterport settings for the above MPC110 overrides. */
 #define MASTERPORT_DEFAULT (BIT(2) | BIT(3) | BIT(6))
@@ -159,6 +322,15 @@ BUILD_ASSERT((SLOT1_ACTIVE1_END % OVERRIDE_ALIGNMENT) == 0);
  * application. The goal of this configuration is to write protect the bootloader code partition
  * from before the Application core is booted by IronSide SE:
  *
+ * |----------------------------------------------------------------------------------------|
+ * | MRAM                                                                                   |
+ * | Bootloader |                                                         | (SECURESTORAGE) |
+ * |----------------------------------------------------------------------------------------|
+ * |    RX      |                                                         |                 |
+ * |----------------------------------------------------------------------------------------|
+ * |            |                          RW                             |                 |
+ * |----------------------------------------------------------------------------------------|
+ *
  * Override 1: R_X | [boot partition start - boot partition end]
  * Override 2: RW  | [boot partition end - end of accessible MRAM]
  *
@@ -176,6 +348,7 @@ static const struct mpcconf_entry uicr_entries[] __used Z_GENERIC_DOT_SECTION(mp
 		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, BOOT_PARTITION_END),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
+
 #if ACCESSIBLE_MRAM_END > BOOT_PARTITION_END
 	/* RW | [boot end - user end] */
 	{
@@ -194,54 +367,48 @@ static const struct mpcconf_entry uicr_entries[] __used Z_GENERIC_DOT_SECTION(mp
 	 */
 };
 
-#if MCUBOOT_IMAGE_NUMBER > 1
-#define SLOT0_RX_END SLOT0_ACTIVE1_END
-#define SLOT1_RX_END SLOT1_ACTIVE1_END
-#else
-#define SLOT0_RX_END SLOT0_ACTIVE0_END
-#define SLOT1_RX_END SLOT1_ACTIVE0_END
-#endif
-
-/* The table(s) below contain the MPC110 override configuration loaded by MCUboot right booting
- * the images, and represents the final MPC configuration (overwriting the one set through UICR).
+/* The table(s) below contain the MPC110 override configuration loaded by MCUboot right before
+ * booting the images, and represents the final MPC configuration (overwriting that set using UICR).
  *
  * The MPC override setup assumes a partition layout as described below.
  * Empty columns represent either inactive images or other space between the adjacent partitions.
  * Parentheses represent optional components.
  *
- * |---------------------------------------------------------------------|
- * | MRAM                                                                |
- * | Bootloader |    | Active 0 |    | (Active 1) |    | (SECURESTORAGE) |
- * |---------------------------------------------------------------------|
- * |                   RX                         |                      |
- * |---------------------------------------------------------------------|
- * |            | RW |          | RW |            | RW |                 |
- * |---------------------------------------------------------------------|
+ * |----------------------------------------------------------------------------------------|
+ * | MRAM                                                                                   |
+ * | Bootloader |   | Act 0 |   | (Act 1) |   | (Act 2) |   | (Act 3) |   | (SECURESTORAGE) |
+ * |----------------------------------------------------------------------------------------|
+ * |                   RX                                                 |                 |
+ * |----------------------------------------------------------------------------------------|
+ * |            |RWX|       |RWX|         |RWX|         |RWX|         |RWX|                 |
+ * |----------------------------------------------------------------------------------------|
  *
  * The goal of the override configuration is to disable write access to the active firmware regions
  * (bootloader + images contained in the slot) and keep write access enabled for other parts of
  * MRAM.
  *
- * Override 1: R_X | [boot partition start - active 0 (active 1) partition end]
- * Override 2: RWX | [boot partition end - active 0 partition start]
- * Override 6: RWX | [active 0 partition end - active 1 partition start]
- * Override 7: RWX | [active 0 (active 1) partition end - end of accessible MRAM]
+ * Override 1:  R_X | [boot partition start - end of accessible MRAM]
+ * Override 2:  RWX | [boot partition end - ACTIVE_0 partition start]
+ * Override 6:  RWX | [ACTIVE_0 end - ACTIVE_1 start] (first inter-image gap when N > 1)
+ * Override 7:  RWX | [ACTIVE_1 end - ACTIVE_2 start] (second inter-image gap when N > 2)
+ * Override 10: RWX | [ACTIVE_2 end - ACTIVE_3 start] (third inter-image gap when N > 3)
+ * Override 11: RWX | [last active partition end - end of accessible MRAM]
  *
  * Note that the effect of overlapping the R_X with RWX is RWX (perms are OR-ed).
  */
-static const struct mpcconf_entry slot0_entries[] = {
-	/* R_X | [boot start - active 1 end] */
+static const struct mpcconf_entry primary_entries[] = {
+	/* R_X | [boot start - user end] */
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(/* LOCK */ true,
 					    /* ENABLE */ true, MPC110_OVERRIDE_DEFAULT_RX),
 		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ false,
 					    /* X */ true,
 					    /* S */ false, ACCESSIBLE_MRAM_START),
-		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SLOT0_RX_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, ACCESSIBLE_MRAM_END),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
-#if SLOT0_ACTIVE0_START > BOOT_PARTITION_END
-	/* RWX | [boot end - active 0 start] */
+
+#if PRIMARY_ACTIVE_0_START > BOOT_PARTITION_END
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(
 			/* LOCK */ true, /* ENABLE */ true,
@@ -249,34 +416,65 @@ static const struct mpcconf_entry slot0_entries[] = {
 		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ true,
 					    /* X */ true,
 					    /* S */ false, BOOT_PARTITION_END),
-		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SLOT0_ACTIVE0_START),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, PRIMARY_ACTIVE_0_START),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
 #endif
+
 #if MCUBOOT_IMAGE_NUMBER > 1
-#if SLOT0_ACTIVE1_START > SLOT0_ACTIVE0_END
-	/* RWX | [active 0 end - active 1 start] */
+#if PRIMARY_ACTIVE_1_START > PRIMARY_ACTIVE_0_END
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(/* LOCK */ true,
 					    /* ENABLE */ true,
 					    MPC110_OVERRIDE_ACTIVE0_END_TO_ACTIVE1_START_RWX),
 		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ true,
 					    /* X */ true,
-					    /* S */ false, SLOT0_ACTIVE0_END),
-		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SLOT0_ACTIVE1_START),
+					    /* S */ false, PRIMARY_ACTIVE_0_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, PRIMARY_ACTIVE_1_START),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
 #endif
+#endif /* MCUBOOT_IMAGE_NUMBER > 1 */
+
+#if MCUBOOT_IMAGE_NUMBER > 2
+#if PRIMARY_ACTIVE_2_START > PRIMARY_ACTIVE_1_END
+	{
+		MPCCONF_ENTRY_CONFIG0_VALUE(/* LOCK */ true,
+					    /* ENABLE */ true,
+					    MPC110_OVERRIDE_ACTIVE1_END_TO_ACTIVE2_START_RWX),
+		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ true,
+					    /* X */ true,
+					    /* S */ false, PRIMARY_ACTIVE_1_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, PRIMARY_ACTIVE_2_START),
+		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
+	},
 #endif
-#if ACCESSIBLE_MRAM_END > SLOT0_RX_END
-	/* RWX | [active 1 end - user end] */
+#endif /* MCUBOOT_IMAGE_NUMBER > 2 */
+
+#if MCUBOOT_IMAGE_NUMBER > 3
+#if PRIMARY_ACTIVE_3_START > PRIMARY_ACTIVE_2_END
+	{
+		MPCCONF_ENTRY_CONFIG0_VALUE(/* LOCK */ true,
+					    /* ENABLE */ true,
+					    MPC110_OVERRIDE_ACTIVE2_END_TO_ACTIVE3_START_RWX),
+		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ true,
+					    /* X */ true,
+					    /* S */ false, PRIMARY_ACTIVE_2_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, PRIMARY_ACTIVE_3_START),
+		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
+	},
+#endif
+#endif /* MCUBOOT_IMAGE_NUMBER > 3 */
+
+#if ACCESSIBLE_MRAM_END > PRIMARY_ACTIVE_3_END
+	/* RWX | [ACTIVE_3 end - user end] */
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(
 			/* LOCK */ true, /* ENABLE */ true,
 			MPC110_OVERRIDE_LAST_ACTIVE_END_TO_ACCESSIBLE_MRAM_END_RWX),
 		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ true,
 					    /* X */ true,
-					    /* S */ false, SLOT0_RX_END),
+					    /* S */ false, PRIMARY_ACTIVE_3_END),
 		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, ACCESSIBLE_MRAM_END),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
@@ -284,19 +482,19 @@ static const struct mpcconf_entry slot0_entries[] = {
 };
 
 #if defined(MCUBOOT_DIRECT_XIP)
-static const struct mpcconf_entry slot1_entries[] = {
-	/* R_X | [boot start - active 1 end] */
+static const struct mpcconf_entry secondary_entries[] = {
+	/* R_X | [boot start - user end] */
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(/* LOCK */ true, /* ENABLE */ true,
 					    MPC110_OVERRIDE_DEFAULT_RX),
 		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ false,
 					    /* X */ true,
 					    /* S */ false, ACCESSIBLE_MRAM_START),
-		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SLOT1_RX_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, ACCESSIBLE_MRAM_END),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
-#if SLOT1_ACTIVE0_START > BOOT_PARTITION_END
-	/* RWX | [boot end - active 0 start] */
+
+#if SECONDARY_ACTIVE_0_START > BOOT_PARTITION_END
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(
 			/* LOCK */ true, /* ENABLE */ true,
@@ -304,40 +502,71 @@ static const struct mpcconf_entry slot1_entries[] = {
 		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ true,
 					    /* X */ true,
 					    /* S */ false, BOOT_PARTITION_END),
-		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SLOT1_ACTIVE0_START),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SECONDARY_ACTIVE_0_START),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
 #endif
+
 #if MCUBOOT_IMAGE_NUMBER > 1
-#if SLOT1_ACTIVE1_START > SLOT1_ACTIVE0_END
-	/* RWX | [active 0 end - active 1 start] */
+#if SECONDARY_ACTIVE_1_START > SECONDARY_ACTIVE_0_END
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(
 			/* LOCK */ true,
 			/* ENABLE */ true, MPC110_OVERRIDE_ACTIVE0_END_TO_ACTIVE1_START_RWX),
 		MPCCONF_ENTRY_CONFIG1_VALUE(
 			/* R */ true, /* W */ true, /* X */ true,
-			/* S */ false, SLOT1_ACTIVE0_END),
-		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SLOT1_ACTIVE1_START),
+			/* S */ false, SECONDARY_ACTIVE_0_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SECONDARY_ACTIVE_1_START),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
 #endif
+#endif /* MCUBOOT_IMAGE_NUMBER > 1 */
+
+#if MCUBOOT_IMAGE_NUMBER > 2
+#if SECONDARY_ACTIVE_2_START > SECONDARY_ACTIVE_1_END
+	{
+		MPCCONF_ENTRY_CONFIG0_VALUE(
+			/* LOCK */ true,
+			/* ENABLE */ true, MPC110_OVERRIDE_ACTIVE1_END_TO_ACTIVE2_START_RWX),
+		MPCCONF_ENTRY_CONFIG1_VALUE(
+			/* R */ true, /* W */ true, /* X */ true,
+			/* S */ false, SECONDARY_ACTIVE_1_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SECONDARY_ACTIVE_2_START),
+		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
+	},
 #endif
-#if ACCESSIBLE_MRAM_END > SLOT1_RX_END
-	/* RWX | [active 1 end - user end] */
+#endif /* MCUBOOT_IMAGE_NUMBER > 2 */
+
+#if MCUBOOT_IMAGE_NUMBER > 3
+#if SECONDARY_ACTIVE_3_START > SECONDARY_ACTIVE_2_END
+	{
+		MPCCONF_ENTRY_CONFIG0_VALUE(
+			/* LOCK */ true,
+			/* ENABLE */ true, MPC110_OVERRIDE_ACTIVE2_END_TO_ACTIVE3_START_RWX),
+		MPCCONF_ENTRY_CONFIG1_VALUE(
+			/* R */ true, /* W */ true, /* X */ true,
+			/* S */ false, SECONDARY_ACTIVE_2_END),
+		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, SECONDARY_ACTIVE_3_START),
+		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
+	},
+#endif
+#endif /* MCUBOOT_IMAGE_NUMBER > 3 */
+
+#if ACCESSIBLE_MRAM_END > SECONDARY_ACTIVE_3_END
+	/* RWX | [ACTIVE_3 end - user end] */
 	{
 		MPCCONF_ENTRY_CONFIG0_VALUE(
 			/* LOCK */ true, /* ENABLE */ true,
 			MPC110_OVERRIDE_LAST_ACTIVE_END_TO_ACCESSIBLE_MRAM_END_RWX),
 		MPCCONF_ENTRY_CONFIG1_VALUE(/* R */ true, /* W */ true,
 					    /* X */ true,
-					    /* S */ false, SLOT1_RX_END),
+					    /* S */ false, SECONDARY_ACTIVE_3_END),
 		MPCCONF_ENTRY_CONFIG2_VALUE(NRF_OWNER_NONE, ACCESSIBLE_MRAM_END),
 		MPCCONF_ENTRY_CONFIG3_VALUE(MASTERPORT_DEFAULT),
 	},
 #endif
 };
-#endif
+#endif /* defined(MCUBOOT_DIRECT_XIP) */
 
 #ifdef MCUBOOT_DIRECT_XIP
 /* Slot to load MPCCONF for. */
@@ -355,9 +584,15 @@ int nrf_mpcconf_update_active_slot(const struct boot_rsp *rsp)
 
 	const uintptr_t abs_addr = flash_base + rsp->br_image_off;
 
-	if (IN_RANGE(abs_addr, SLOT1_ACTIVE0_START, SLOT1_ACTIVE0_END - 1)
+	if (IN_RANGE(abs_addr, SECONDARY_P0_START, SECONDARY_P0_END - 1)
 #if MCUBOOT_IMAGE_NUMBER > 1
-	    || IN_RANGE(abs_addr, SLOT1_ACTIVE1_START, SLOT1_ACTIVE1_END - 1)
+	    || IN_RANGE(abs_addr, SECONDARY_P1_START, SECONDARY_P1_END - 1)
+#endif
+#if MCUBOOT_IMAGE_NUMBER > 2
+	    || IN_RANGE(abs_addr, SECONDARY_P2_START, SECONDARY_P2_END - 1)
+#endif
+#if MCUBOOT_IMAGE_NUMBER > 3
+	    || IN_RANGE(abs_addr, SECONDARY_P3_START, SECONDARY_P3_END - 1)
 #endif
 	) {
 		mpcconf_slot = BOOT_SLOT_SECONDARY;
@@ -386,20 +621,20 @@ int __ramfunc nrf_load_mpcconf(void)
 #ifdef MCUBOOT_DIRECT_XIP
 	switch (mpcconf_slot) {
 	case BOOT_SLOT_PRIMARY:
-		entries = slot0_entries;
-		num_entries = ARRAY_SIZE(slot0_entries);
+		entries = primary_entries;
+		num_entries = ARRAY_SIZE(primary_entries);
 		break;
 	case BOOT_SLOT_SECONDARY:
-		entries = slot1_entries;
-		num_entries = ARRAY_SIZE(slot1_entries);
+		entries = secondary_entries;
+		num_entries = ARRAY_SIZE(secondary_entries);
 		break;
 	default:
 		/* Should not be possible. */
 		return -1;
 	}
 #else
-	entries = slot0_entries;
-	num_entries = ARRAY_SIZE(slot0_entries);
+	entries = primary_entries;
+	num_entries = ARRAY_SIZE(primary_entries);
 #endif /* MCUBOOT_DIRECT_XIP */
 
 	status = ironside_se_mpcconf_write(entries, num_entries);


### PR DESCRIPTION
manifest-pr-skip

Update the MPCCONF tables used to write protect the image partitions
on nRF54H20 to support up to 4 images.

This is the maximum number of distinct partitions possible to write
protect with the available overrrides in MPC110 without introducing
additional restrictions, like disallowing some gaps between partitions
or adding owner ID based restrictions.