### PR TITLE
[nrf fromlist] boot: zephyr: socs: Add nrf54h20 Kconfig fragment

### DIFF
--- a/boot/zephyr/socs/nrf54h20_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54h20_cpuapp.conf
@@ -24,3 +24,5 @@ CONFIG_BOOT_WATCHDOG_FEED=n
 # Power domains forced on by default on boot, no need
 # to manage them in bootloader.
 CONFIG_POWER_DOMAIN=n
+
+CONFIG_MULTITHREADING=y


### PR DESCRIPTION
Upstream PR #: 2681

Adds a Kconfig fragment needed for MRAM access


(cherry picked from commit 8e9d9bab85df51030146a9d5b5278567015e1db0)