### PR TITLE
[nrf noup] boot: zephyr: Replace haltium header includes with soc-specific headers

### DIFF
--- a/boot/zephyr/nrf54h20_custom_s2ram.c
+++ b/boot/zephyr/nrf54h20_custom_s2ram.c
@@ -6,8 +6,8 @@
 #include <stdbool.h>
 #include <zephyr/arch/common/pm_s2ram.h>
 #include <hal/nrf_resetinfo.h>
-#include "haltium_pm_s2ram.h"
-#include "haltium_power.h"
+#include "soc_pm_s2ram.h"
+#include "soc_power.h"
 
 #include <zephyr/devicetree.h>
 #include <zephyr/storage/flash_map.h>


### PR DESCRIPTION
Replace includes of removed common haltium_pm_s2ram.h and haltium_power.h headers with the per-SoC series soc_pm_s2ram.h and soc_power.h equivalents introduced in the Zephyr SoC layer.

manifest-pr-skip