### PR TITLE
[nrf noup] boot/zephyr/boards: DTS partitioning for nrf54lm20dongle

### DIFF
--- a/boot/zephyr/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.overlay
+++ b/boot/zephyr/boards/nrf54lm20dongle_nrf54lm20b_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* This is nRF54lm20dongle_nrf54lm20b_cpuapp peculiar partitioning for MCUboot and firmware loader
+ * slot0_partition spans RRAM with can be update by the firmware loader and booted by MCUboot.
+ * beginning of the slot0_partition must match with the beginning of the slot0_partition of the user
+ * application. Althought Application can be build for smaler partition and live some space for
+ * other purposes like a storage partition.
+ */
+
+/delete-node/ &storage_partition;
+
+&cpuapp_rram {
+	partitions {
+		slot0_partition: partition@23000 {
+			label = "image-0";
+			reg = <0x23000 DT_SIZE_K(1896)>;
+		};
+	};
+};


### PR DESCRIPTION
Added DTS overlay for partitions on nRF54LM20dongle. This is for firmware loader - slot0_parttion spans till end of RRAM. An application build must keep the same start address but can downsize the partition.

in pair with https://github.com/nrfconnect/sdk-nrf/pull/28154