### PR TITLE
[nrf noup] zephyr: socs: nrf54ls05b defaults

### DIFF
--- a/boot/zephyr/socs/nrf54ls05a_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54ls05a_cpuapp.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Ensure that the SPI NOR driver is disabled by default
+CONFIG_SPI_NOR=n
+
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y
+
+CONFIG_BOOT_WATCHDOG_FEED=n

--- a/boot/zephyr/socs/nrf54ls05b_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54ls05b_cpuapp.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Ensure that the SPI NOR driver is disabled by default
+CONFIG_SPI_NOR=n
+
+CONFIG_NCS_MCUBOOT_DISABLE_SELF_RWX=y
+
+CONFIG_BOOT_WATCHDOG_FEED=n


### PR DESCRIPTION
adds nrf54ls04b soc default configuration