### PR TITLE
[nrf noup] zephyr: sysflash: Add missing NETCORE partition support

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -822,11 +822,14 @@ check_validity:
             check_addresses = true;
         } else
 #endif
+#ifdef MCUBOOT_IS_SECOND_STAGE
         if (IMAGE_IS_SECOND_STAGE_MCUBOOT(state)) {
             min_addr = SECOND_STAGE_INACTIVE_MCUBOOT_OFFSET;
             max_addr = (SECOND_STAGE_INACTIVE_MCUBOOT_OFFSET + SECOND_STAGE_INACTIVE_MCUBOOT_SIZE);
             check_addresses = true;
-        } else if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER) {
+        } else
+#endif
+        if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER) {
             min_addr = flash_area_get_off(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY));
             max_addr = flash_area_get_size(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY)) + min_addr;
 

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -841,3 +841,24 @@ if(SYSBUILD AND CONFIG_PCD_APP)
     set(RAM_FLASH_ADDR "${ram_flash_addr}" CACHE STRING "" FORCE)
     set(RAM_FLASH_SIZE "${ram_flash_size}" CACHE STRING "" FORCE)
 endif()
+
+if(NOT CONFIG_PARTITION_MANAGER_ENABLED AND CONFIG_SOC_NRF5340_CPUAPP)
+  if(CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER AND NOT CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER EQUAL -1)
+    if(NOT TARGET b0n_target)
+      add_custom_target(b0n_target)
+      zephyr_dt_import(EDT_PICKLE_FILE ${CMAKE_BINARY_DIR}/../b0n/zephyr/edt.pickle TARGET b0n_target)
+    endif()
+    # Really this dependency if set for MCUboot, but it will also cover s1 image,
+    # since contition that let us here checks for `CONFIG_MCUBOOT` which is only
+    # set for MCUboot builds.
+    add_dependencies(${TARGET_NAME} b0n_target)
+
+    dt_nodelabel(s0_partition_path NODELABEL s0_partition REQUIRED TARGET b0n_target)
+    dt_reg_addr(s0_partition_address PATH ${s0_partition_path} TARGET b0n_target)
+    dt_reg_size(s0_partition_size PATH ${s0_partition_path} TARGET b0n_target)
+    # Using same identifiers as nrf5340 hooks use, as they represnt the same
+    # information in hooks.
+    zephyr_compile_definitions("PCD_NET_CORE_APP_ADDRESS=${s0_partition_address}")
+    zephyr_compile_definitions("PCD_NET_CORE_APP_SIZE=${s0_partition_size}")
+  endif()
+endif()

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -43,6 +43,13 @@
 #define SPI_FLASH_0_ID 1
 #endif
 
+/* Support for NETCPU application image updates */
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#define NETCPU_APP_SLOT_OFFSET  PCD_NET_CORE_APP_ADDRESS
+#define NETCPU_APP_SLOT_SIZE    PCD_NET_CORE_APP_SIZE
+#define NETCPU_APP_SLOT_END     (NETCPU_APP_SLOT_OFFSET + NETCPU_APP_SLOT_SIZE)
+#endif
+
 /* This is workaround because of bootutil public interface also requiring this
  * file. In reality application is supposed to maintain flash area access,
  * but bootutil uses own definitions, taken directly from DTS, which includes


### PR DESCRIPTION
Add missing definitions for NETCORE partition used by nRF5340.