### PR TITLE
[nrf fromtree] boot: zephyr: socs: Add nrf54h20 Kconfig fragment

### DIFF
--- a/boot/zephyr/socs/nrf54h20_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54h20_cpuapp.conf
@@ -24,3 +24,5 @@ CONFIG_BOOT_WATCHDOG_FEED=n
 # Power domains forced on by default on boot, no need
 # to manage them in bootloader.
 CONFIG_POWER_DOMAIN=n
+
+CONFIG_MULTITHREADING=y


### PR DESCRIPTION
Adds a Kconfig fragment needed for MRAM access: as MRAM writes could stall if the ready register is not checked before any write, as multiple cores can trigger a write at the same time. In order to disable that mode in the controller before any write, we need to use the mram_latency service which is the only way to to disable auto power-down mode, which needs EVENTS, and EVENTS depends on MULTITHREADING.


(cherry picked from commit a075f6646f5cfeb5cc466c9863f788e2b3a0c7c5)