### PR TITLE
[nrf noup] bootloader: Add RSA support via PSA core lite

### DIFF
--- a/boot/bootutil/src/image_rsa_nrf.c
+++ b/boot/bootutil/src/image_rsa_nrf.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+
+#include <string.h>
+
+#include "mcuboot_config/mcuboot_config.h"
+
+#include "bootutil/sign_key.h"
+
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "bootutil/bootutil_log.h"
+#include "bootutil/crypto/sha.h"
+#include "bootutil_priv.h"
+
+BOOT_LOG_MODULE_DECLARE(mcuboot);
+
+#ifdef MCUBOOT_SIGN_RSA
+#include <psa/crypto.h>
+#include <psa/crypto_types.h>
+#include <zephyr/sys/util.h>
+#include "bootutil_priv.h"
+#include "bootutil/sign_key.h"
+#include "bootutil/fault_injection_hardening.h"
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+#include <nrf_lcs/nrf_lcs.h>
+#endif
+#define RSA_SIGNATURE_LENGTH        (256)
+#define RSA_PUBLIC_KEY_BIT_SIZE     (2048)
+
+extern const unsigned int rsa_pub_key_len;
+
+int rsa_verify(const uint8_t *message, size_t message_len,
+                   const uint8_t signature[RSA_SIGNATURE_LENGTH],
+                   const uint8_t public_key[PSA_EXPORT_PUBLIC_KEY_MAX_SIZE])
+{
+    /* Set to any error */
+    psa_status_t status = PSA_ERROR_BAD_STATE;
+    psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
+    int ret = 0;        /* Fail by default */
+    psa_key_id_t key_id;
+
+    BOOT_LOG_DBG("rsa_verify: PSA implementation, plain key");
+
+    /* Initialize PSA Crypto */
+    status = psa_crypto_init();
+    if (status != PSA_SUCCESS) {
+        BOOT_LOG_ERR("PSA crypto init failed %d\n", status);
+        return 0;
+    }
+
+    status = PSA_ERROR_BAD_STATE;
+
+    psa_set_key_usage_flags(&key_attr, PSA_KEY_USAGE_VERIFY_HASH);
+    psa_set_key_lifetime(&key_attr, PSA_KEY_LIFETIME_VOLATILE);
+    psa_set_key_algorithm(&key_attr, PSA_ALG_RSA_PSS(PSA_ALG_SHA_256));
+    psa_set_key_type(&key_attr, PSA_KEY_TYPE_RSA_PUBLIC_KEY);
+    psa_set_key_bits(&key_attr, RSA_PUBLIC_KEY_BIT_SIZE);
+
+    BOOT_LOG_DBG("Importing RSA PSS key of size: %d", rsa_pub_key_len);
+
+    status = psa_import_key(&key_attr, public_key, rsa_pub_key_len,
+                            &key_id);
+    if (status != PSA_SUCCESS) {
+        BOOT_LOG_ERR("RSA import key failed %d", status);
+        ret = 0;
+    }
+
+    BOOT_LOG_DBG("Key imported. key_id: %d", (int)key_id);
+
+    status = PSA_ERROR_BAD_STATE;
+
+    BOOT_LOG_INF("Verifying RSA PSS with signature len: %d", RSA_SIGNATURE_LENGTH);
+
+    status = psa_verify_hash(key_id, PSA_ALG_RSA_PSS(PSA_ALG_SHA_256),
+                             message, message_len, signature, RSA_SIGNATURE_LENGTH);
+    if (status != PSA_SUCCESS) {
+        BOOT_LOG_ERR("RSA signature verification failed %d", status);
+        ret = 0;
+    } else {
+        BOOT_LOG_INF("RSA signature verification successful");
+        ret = 1;
+    }
+
+    status = psa_destroy_key(key_id);
+    if (status != PSA_SUCCESS) {
+        BOOT_LOG_ERR("Failed to destroy imported public key: %d", status);
+        ret = 0;
+    } else {
+        BOOT_LOG_DBG("Destroyed imported key");
+    }
+
+    return ret;
+}
+
+
+static fih_ret
+bootutil_verify(uint8_t *buf, uint32_t blen,
+                uint8_t *sig, size_t slen,
+                uint8_t key_id)
+{
+    int rc;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
+    uint8_t *pubkey = NULL;
+
+#ifdef CONFIG_NCS_MCUBOOT_LCS_AWARE
+    if (nrf_lcs_get() != NRF_LCS_SECURED) {
+        if (key_id != CONFIG_NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER) {
+            BOOT_LOG_ERR("bootutil_verify_sig: invalid key ID %d for non-secured device", key_id);
+            FIH_RET(FIH_FAILURE);
+        }
+        BOOT_LOG_DBG("bootutil_verify_sig: using manufacturing application key ID %d", key_id);
+    }
+#endif /* CONFIG_NCS_MCUBOOT_LCS_AWARE */
+
+    BOOT_LOG_DBG("bootutil_verify_sig: RSA key_id %d", key_id);
+
+    if (slen != RSA_SIGNATURE_LENGTH) {
+        BOOT_LOG_DBG("bootutil_verify: expected slen %d, got %u",
+                     RSA_SIGNATURE_LENGTH, (unsigned int)slen);
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
+    }
+
+    pubkey = (uint8_t *)bootutil_keys[key_id].key;
+
+    BOOT_LOG_DBG("bootutil_verify: RSA key_id %d", (int)key_id);
+
+    rc = rsa_verify(buf, blen, sig, pubkey);
+
+    BOOT_LOG_DBG("bootutil_verify: rsa_verify status %d", rc);
+
+    if (rc == 0) {
+        /* if verify returns 0, there was an error. */
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
+    }
+
+    FIH_SET(fih_rc, FIH_SUCCESS);
+out:
+
+    FIH_RET(fih_rc);
+}
+
+/* Hash signature verification function.
+ * Verifies hash against provided signature.
+ * The function verifies that hash is of expected size and then
+ * calls bootutil_verify to do the signature verification.
+ */
+fih_ret
+bootutil_verify_sig(uint8_t *hash, uint32_t hlen,
+                    uint8_t *sig, size_t slen,
+                    uint8_t key_id)
+{
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
+
+    BOOT_LOG_DBG("bootutil_verify_sig: RSA key_id %d", (int)key_id);
+
+    if (hlen != IMAGE_HASH_SIZE) {
+        BOOT_LOG_DBG("bootutil_verify_sig: expected hlen %d, got %d",
+                     IMAGE_HASH_SIZE, hlen);
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
+    }
+
+    FIH_CALL(bootutil_verify, fih_rc, hash, IMAGE_HASH_SIZE, sig,
+             slen, key_id);
+
+out:
+    FIH_RET(fih_rc);
+}
+
+/* Image verification function.
+ * The function directly calls bootutil_verify to verify signature
+ * of image.
+ */
+fih_ret
+bootutil_verify_img(uint8_t *img, uint32_t size,
+                    uint8_t *sig, size_t slen,
+                    uint8_t key_id)
+{
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
+
+    BOOT_LOG_DBG("bootutil_verify_img: RSA key_id %d", (int)key_id);
+
+    FIH_CALL(bootutil_verify, fih_rc, img, size, sig,
+             slen, key_id);
+
+    FIH_RET(fih_rc);
+}
+
+#endif /* MCUBOOT_SIGN_RSA */

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -118,7 +118,7 @@ zephyr_library_sources(
   ${BOOT_DIR}/bootutil/src/mcuboot_manifest.c
   ${BOOT_DIR}/bootutil/src/tlv.c
   ${BOOT_DIR}/bootutil/src/encrypted.c
-  ${BOOT_DIR}/bootutil/src/image_rsa.c
+  ${BOOT_DIR}/bootutil/src/image_rsa_nrf.c
   ${BOOT_DIR}/bootutil/src/image_ecdsa.c
   ${BOOT_DIR}/bootutil/src/image_ed25519.c
   ${BOOT_DIR}/bootutil/src/bootutil_misc.c

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -22,9 +22,19 @@ config MCUBOOT
 	select MCUBOOT_BOOTUTIL_LIB
 	select REBOOT if SECURE_BOOT
 
+config BOOT_USE_MBEDTLS_INCLUDES
+	bool
+	# Hidden option
+	select NRF_SECURITY
+	help
+	  Hidden option set if Mbed TLS includes are needed. The includes comes
+	  from Oberon PSA crypto. This is required for ASN.1 encoding information
+	  via the include <mbedtls_oid.h> which is used regardless of implementation.
+
 config BOOT_USE_MBEDTLS
 	bool
 	# Hidden option
+	select BOOT_USES_MBEDTLS_INCLUDES
 	help
 	  Use mbedTLS for crypto primitives.
 
@@ -258,26 +268,15 @@ choice BOOT_SIGNATURE_TYPE
 config BOOT_SIGNATURE_TYPE_NONE
 	bool "No signature; use only hash check"
 	select BOOT_USE_TINYCRYPT if !SOC_SERIES_NRF54L
-	select BOOT_USE_PSA_CRYPTO if SOC_SERIES_NRF54L
+	select BOOT_USE_PSA_CRYPTO
 	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
 
 config BOOT_SIGNATURE_TYPE_RSA
 	bool "RSA signatures"
-	select BOOT_USE_MBEDTLS
-	select PSA_CRYPTO
-	select PSA_WANT_KEY_TYPE_AES
-	select PSA_WANT_ALG_CTR
-	select MBEDTLS_DECLARE_PRIVATE_IDENTIFIERS
-	select MBEDTLS_ASN1_PARSE_C
-	select MBEDTLS_MD_C
-	select MBEDTLS_SHA256_C
-	select MBEDTLS_RSA_C
-	select MBEDTLS_PKCS1_V15
-	select MBEDTLS_PKCS1_V21
-	select MBEDTLS_KEY_EXCHANGE_RSA_ENABLED if NRF_SECURITY
-	select MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
-	select MBEDTLS_PLATFORM_SNPRINTF_ALT
-	select BOOT_ENCRYPTION_SUPPORT
+	select BOOT_USE_PSA_CRYPTO
+	select PSA_WANT_ALG_SHA_256
+	select PSA_WANT_ALG_RSA_PSS
+	select PSA_WANT_KEY_TYPE_RSA_PUBLIC_KEY
 	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
 
 if BOOT_SIGNATURE_TYPE_RSA
@@ -291,9 +290,7 @@ config BOOT_SIGNATURE_TYPE_ECDSA_P256
 	bool "Elliptic curve digital signatures with curve P-256"
 	select BOOT_ENCRYPTION_SUPPORT
 	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
-	# Enable nrf_security for include paths to oberon-psa-crypto which has mbedtls headers
-	# (e.g. crypto_oid.h), needed also in cases other than BOOT_ECDSA_PSA.
-	select NRF_SECURITY
+	select BOOT_USE_MBEDTLS_INCLUDES
 	imply MBEDTLS_ASN1_PARSE_C
 
 if BOOT_SIGNATURE_TYPE_ECDSA_P256
@@ -336,11 +333,9 @@ config BOOT_SIGNATURE_TYPE_ED25519
 	bool "Edwards curve digital signatures using ed25519"
 	select BOOT_ENCRYPTION_SUPPORT if !BOOT_SIGNATURE_TYPE_PURE
 	select BOOT_IMG_HASH_ALG_SHA256_ALLOW if !BOOT_SIGNATURE_TYPE_PURE
+	select BOOT_USE_MBEDTLS_INCLUDES
 	# The SHA is used only for key hashing, not for images.
 	select BOOT_SIGNATURE_TYPE_PURE_ALLOW
-	# Enable nrf_security for include paths to oberon-psa-crypto which has mbedtls headers
-	# (e.g. crypto_oid.h), needed also in cases other than BOOT_ED25519_PSA.
-	select NRF_SECURITY
 	help
 	  This is ed25519 signature calculated over SHA512 of SHA256 of application
 	  image.


### PR DESCRIPTION
-This commit adds RSA support via PSA core lite.
-This commit removes dependencies for legacy Mbed TLS APIs for RSA. -The change is provided as an additional source file to prevent
 continued conflict-resolution when MCUboot is synchronized with
 upstream. The original image_rsa.c is not used. Instead
 image_rsa_nrf.c is used