### PR TITLE
[nrf noup] zephyr: sysflash: Fix undefined TARGET_NAME in dependency

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -849,7 +849,7 @@ if(NOT CONFIG_PARTITION_MANAGER_ENABLED AND CONFIG_SOC_NRF5340_CPUAPP)
     # Really this dependency if set for MCUboot, but it will also cover s1 image,
     # since contition that let us here checks for `CONFIG_MCUBOOT` which is only
     # set for MCUboot builds.
-    add_dependencies(${TARGET_NAME} b0n_target)
+    add_dependencies(app b0n_target)
 
     dt_nodelabel(s0_partition_path NODELABEL s0_partition REQUIRED TARGET b0n_target)
     dt_reg_addr(s0_partition_address PATH ${s0_partition_path} TARGET b0n_target)


### PR DESCRIPTION
## Summary

The `add_dependencies()` call introduced in commit [`13e582da`](https://github.com/nrfconnect/sdk-mcuboot/commit/13e582da7d2cff2dff7728b4b6cfbaff7e0c20d4) (`[nrf noup] zephyr: sysflash: Add missing NETCORE partition support`) references `${TARGET_NAME}`, which is not defined anywhere in MCUboot's CMake or Kconfig. CMake expands it to an empty string and the configure step fails with:

```
CMake Error at CMakeLists.txt:854 (add_dependencies):
  add_dependencies called with incorrect number of arguments
```

This breaks every build entering the new code path, that is:

- `CONFIG_PARTITION_MANAGER_ENABLED=n`
- `CONFIG_SOC_NRF5340_CPUAPP=y`
- `CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER` set to a real image (not `-1`)

This is exactly the configuration used by samples that migrate their nRF53 multi-image build off Partition Manager (for example the Fast Pair Locator Tag sample DTS migration in [nrfconnect/sdk-nrf#28462](https://github.com/nrfconnect/sdk-nrf/pull/28462)).

## Fix

Replace `${TARGET_NAME}` with the standard Zephyr application library target name `app`, matching how `add_dependencies()` is used elsewhere across the tree (e.g. `zephyr/samples/tfm_integration/tfm_psa_test/CMakeLists.txt`, `modules/lib/matter/config/nrfconnect/chip-module/CMakeLists.txt`).

## Test plan

- [x] Clean `west build -b nrf5340dk/nrf5340/cpuapp` of the Fast Pair Locator Tag sample with `SB_CONFIG_PARTITION_MANAGER=n` configures and links cleanly (all 53 ninja steps), including `b0n_provision_merged.hex` and `signed_by_mcuboot_and_b0_ipc_radio.hex`.
- [x] No regressions in the PM-based build path (`CONFIG_PARTITION_MANAGER_ENABLED=y` skips the offending block entirely).