### PR TITLE
NCSDK-35089: loader: Handle encrypted MCUboot updates

### DIFF
--- a/boot/bootutil/include/bootutil/mcuboot_uuid.h
+++ b/boot/bootutil/include/bootutil/mcuboot_uuid.h
@@ -57,6 +57,21 @@ fih_ret boot_uuid_vid_match(const struct flash_area *fap, const struct image_uui
  */
 fih_ret boot_uuid_cid_match(const struct flash_area *fap, const struct image_uuid *uuid_cid);
 
+/**
+ * @brief Find the image index and partition index for a given class ID and vendor ID.
+ *
+ * @param[in]  cid              The class ID to search for.
+ * @param[in]  vid              The vendor ID to search for.
+ * @param[out] image_index      The index of the image found.
+ * @param[out] partition_index  The index of the partition found.
+ *
+ * @retval 0 on success,
+ * @retval -EINVAL if the input parameters are invalid.
+ * @retval -ENOENT if the image or partition is not found.
+ */
+int boot_uuid_find_image(const struct image_uuid *cid, const struct image_uuid *vid,
+			 size_t *image_index, size_t *partition_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/boot/bootutil/src/bootutil_loader.c
+++ b/boot/bootutil/src/bootutil_loader.c
@@ -132,6 +132,14 @@ boot_check_header_valid(struct boot_loader_state *state, int slot)
     }
 #endif
 
+#ifdef MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
+    if ((hdr->ih_flags & (IMAGE_F_ROM_FIXED | IMAGE_F_RAM_LOAD)) == 0) {
+        BOOT_LOG_ERR("IMAGE_F_ROM_FIXED | IMAGE_F_RAM_LOAD is not set for image %d slot %d",
+            BOOT_CURR_IMG(state), slot);
+        return false;
+    }
+#endif
+
     return true;
 }
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -785,7 +785,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
 #endif
 
         if (rc < 0 &&
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && \
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && defined(CONFIG_SOC_NRF5340_CPUAPP) && \
     !defined(CONFIG_MCUBOOT_DOWNGRADE_PREVENTION) || !defined(CONFIG_PCD_READ_NETCORE_APP_VERSION)
             CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != BOOT_CURR_IMG(state) &&
 #endif
@@ -1738,13 +1738,13 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
          */
         hdr = boot_img_hdr(state, BOOT_SLOT_PRIMARY);
         if (hdr->ih_magic == IMAGE_MAGIC) {
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && defined(CONFIG_SOC_NRF5340_CPUAPP)
             if (image_index == CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER) {
                 rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &copy_size);
             } else {
 #endif
                 rc = boot_read_image_size(state, BOOT_SLOT_PRIMARY, &copy_size);
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && defined(CONFIG_SOC_NRF5340_CPUAPP)
             }
 #endif
             assert(rc == 0);

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -92,6 +92,18 @@ int pcd_version_cmp_net(const struct flash_area *fap, struct image_header *hdr);
 #include <load_ironside_se_conf.h>
 #endif
 
+#if defined(CONFIG_MCUBOOT_UUID_CID)
+#include "bootutil/mcuboot_uuid.h"
+
+#ifdef SECOND_STAGE_MCUBOOT_RUNNING_FROM_S0
+#define MCUBOOT_INACTIVE_PARTITION_INDEX 1
+#define MCUBOOT_ACTIVE_PARTITION_INDEX 0
+#else
+#define MCUBOOT_INACTIVE_PARTITION_INDEX 0
+#define MCUBOOT_ACTIVE_PARTITION_INDEX 1
+#endif
+#endif
+
 #ifdef CONFIG_SOC_EARLY_RESET_HOOK
 void s2ram_designate_slot(uint8_t slot);
 #endif
@@ -605,9 +617,15 @@ boot_rom_address_check(struct boot_loader_state *state)
 }
 #endif
 
-#if (((defined(MCUBOOT_VERIFY_IMG_ADDRESS) && !defined(MCUBOOT_ENC_IMAGES)) \
-  || defined(MCUBOOT_CHECK_HEADER_LOAD_ADDRESS)) ||\
-  defined(MCUBOOT_IS_SECOND_STAGE))
+#if (CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1) && !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE) \
+    && defined(CONFIG_PCD_APP)
+#define INCLUDE_NETWORK_CORE_IMAGE_CHECK
+#endif
+
+#if ((defined(MCUBOOT_VERIFY_IMG_ADDRESS) && !defined(MCUBOOT_ENC_IMAGES)) || \
+     defined(MCUBOOT_CHECK_HEADER_LOAD_ADDRESS)) || \
+    (!defined(CONFIG_MCUBOOT_UUID_CID) && (defined(INCLUDE_NETWORK_CORE_IMAGE_CHECK) || \
+     defined(MCUBOOT_IS_SECOND_STAGE)))
 static void
 get_image_perspective_flash_area_bounds(const struct flash_area *fa, uint32_t *start, uint32_t *end)
 {
@@ -1048,6 +1066,56 @@ static inline void sec_slot_cleanup_if_unusable(void)
 #endif /* defined(CONFIG_MCUBOOT_CLEANUP_UNUSABLE_SECONDARY) &&\
           defined(MCUBOOT_IS_SECOND_STAGE) || defined(CONFIG_SOC_NRF5340_CPUAPP) */
 
+#ifdef CONFIG_MCUBOOT_UUID_CID
+/**
+ * Read the image UUID from the TLV.
+ *
+ * @param[in]  fap       Pointer to the flash area structure.
+ * @param[in]  hdr       Pointer to the image header structure.
+ * @param[in]  tlv_type  The type of the TLV to read.
+ * @param[out] uuid      Pointer to the image UUID structure.
+ *
+ * @return 0       on success,
+ * @retval -EINVAL if the input parameters are invalid.
+ * @retval -EIO    if the TLV cannot be read.
+ * @retval -ENOENT if the TLV cannot be found.
+ */
+int read_image_uuid_tlv(const struct flash_area *fap,
+			            const struct image_header *hdr,
+			            uint16_t tlv_type,
+			            struct image_uuid *uuid)
+{
+	struct image_tlv_iter it;
+	uint32_t off;
+	uint16_t len;
+	int rc;
+
+	if ((fap == NULL) || (hdr == NULL) || (uuid == NULL)) {
+		return -EINVAL;
+	}
+
+	rc = bootutil_tlv_iter_begin(&it, hdr, fap, tlv_type, false);
+	if (rc != 0) {
+		return -ENOENT;
+	}
+
+	rc = bootutil_tlv_iter_next(&it, &off, &len, NULL);
+	if (rc != 0) {
+		return -ENOENT;
+	}
+
+	if (len != sizeof(uuid->raw)) {
+		return -EINVAL;
+	}
+
+	if (flash_area_read(fap, off, uuid->raw, len) != 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_MCUBOOT_UUID_CID */
+
 /**
  * Determines which swap operation to perform, if any.  If it is determined
  * that a swap operation is required, the image in the secondary slot is checked
@@ -1062,19 +1130,24 @@ boot_validated_swap_type(struct boot_loader_state *state,
 {
     int swap_type;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
+#ifdef INCLUDE_NETWORK_CORE_IMAGE_CHECK
     bool upgrade_valid = false;
-
-#if defined(MCUBOOT_IS_SECOND_STAGE) \
-    || (CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 \
-        && (!defined(MCUBOOT_CHECK_HEADER_LOAD_ADDRESS) \
-            || (!defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE) && defined(CONFIG_PCD_APP))))
-    int rc;
-    const struct flash_area *secondary_fa = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
 #endif
 
-#if defined(MCUBOOT_IS_SECOND_STAGE) || CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if defined(INCLUDE_NETWORK_CORE_IMAGE_CHECK) || defined(MCUBOOT_IS_SECOND_STAGE)
+    const struct flash_area *secondary_fa = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
     struct image_header *hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
+    int rc = 0;
+#ifdef CONFIG_MCUBOOT_UUID_CID
+    struct image_uuid img_uuid_cid;
+#ifdef MCUBOOT_UUID_VID
+    struct image_uuid img_uuid_vid;
+#endif
+    size_t target_image = 0;
+    size_t target_partition = 0;
+#else
     uint32_t internal_img_addr = 0;
+#endif
     /* Patch needed for NCS. Since image 0 (the app) and image 1 (the other
      * B1 slot S0 or S1) share the same secondary slot, we need to check
      * whether the update candidate in the secondary slot is intended for
@@ -1085,6 +1158,8 @@ boot_validated_swap_type(struct boot_loader_state *state,
      */
     NSIB_OWNED_UNSET(BOOT_CURR_IMG(state));
 
+#if !defined(CONFIG_MCUBOOT_UUID_CID) && (defined(INCLUDE_NETWORK_CORE_IMAGE_CHECK) || \
+    defined(MCUBOOT_IS_SECOND_STAGE))
     if (hdr->ih_magic == IMAGE_MAGIC) {
 #ifdef MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
         internal_img_addr = hdr->ih_load_addr;
@@ -1102,7 +1177,7 @@ boot_validated_swap_type(struct boot_loader_state *state,
         sec_slot_touch(state);
 
 #ifdef  MCUBOOT_IS_SECOND_STAGE
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#ifdef INCLUDE_NETWORK_CORE_IMAGE_CHECK
         if (!(internal_img_addr >= NETCPU_APP_SLOT_OFFSET &&
               internal_img_addr < NETCPU_APP_SLOT_END))
 #endif
@@ -1158,7 +1233,62 @@ boot_validated_swap_type(struct boot_loader_state *state,
         sec_slot_mark_assigned(state);
     }
 
-#endif /* MCUBOOT_IS_SECOND_STAGE || CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 */
+#elif defined(CONFIG_MCUBOOT_UUID_CID)
+    if (hdr->ih_magic == IMAGE_MAGIC) {
+        rc = read_image_uuid_tlv(secondary_fa, hdr, IMAGE_TLV_UUID_CID, &img_uuid_cid);
+        if (rc != 0) {
+            return BOOT_SWAP_TYPE_NONE;
+        }
+#ifdef MCUBOOT_UUID_VID
+        rc = read_image_uuid_tlv(secondary_fa, hdr, IMAGE_TLV_UUID_VID, &img_uuid_vid);
+        if (rc != 0) {
+            return BOOT_SWAP_TYPE_NONE;
+        }
+#endif
+
+        sec_slot_touch(state);
+
+        rc = boot_uuid_find_image(&img_uuid_cid,
+#ifdef MCUBOOT_UUID_VID
+                                  &img_uuid_vid,
+#else
+                                  NULL,
+#endif
+                                  &target_image, &target_partition);
+        if (rc != 0) {
+            /* Unable to find a matching image index. */
+            BOOT_LOG_ERR("Image in slot does not match any known UUID");
+            flash_area_erase(secondary_fa, 0, secondary_fa->fa_size);
+            sec_slot_untouch(state);
+            BOOT_LOG_ERR("Cleaned-up secondary slot of image %d", BOOT_CURR_IMG(state));
+            return BOOT_SWAP_TYPE_FAIL;
+        }
+
+        if (target_image == CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER) {
+            /* This is a valid network core update candidate. */
+#ifdef  MCUBOOT_IS_SECOND_STAGE
+        } else if ((target_image == CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER) &&
+                   (target_partition == MCUBOOT_INACTIVE_PARTITION_INDEX)) {
+            /* This is a valid MCUboot update candidate. */
+            NSIB_OWNED_SET(BOOT_CURR_IMG(state));
+        } else if ((target_image == CONFIG_MCUBOOT_MCUBOOT_IMAGE_NUMBER) &&
+                   (target_partition == MCUBOOT_ACTIVE_PARTITION_INDEX)) {
+            /* NSIB upgrade but for the wrong slot, must be erased */
+            BOOT_LOG_ERR("Image in slot is for wrong s0/s1 image");
+            flash_area_erase(secondary_fa, 0, secondary_fa->fa_size);
+            sec_slot_untouch(state);
+            BOOT_LOG_ERR("Cleaned-up secondary slot of image %d", BOOT_CURR_IMG(state));
+            return BOOT_SWAP_TYPE_FAIL;
+#endif /* MCUBOOT_IS_SECOND_STAGE */
+        } else {
+            /* The image in the secondary slot is not intended for any */
+            return BOOT_SWAP_TYPE_NONE;
+        }
+
+        sec_slot_mark_assigned(state);
+    }
+#endif /* CONFIG_MCUBOOT_UUID_CID */
+#endif /* defined(MCUBOOT_IS_SECOND_STAGE) || defined(INCLUDE_NETWORK_CORE_IMAGE_CHECK) */
 
     swap_type = boot_swap_type_multi(BOOT_CURR_IMG(state));
     if (BOOT_IS_UPGRADE(swap_type)) {
@@ -1172,18 +1302,25 @@ boot_validated_swap_type(struct boot_loader_state *state,
             } else {
                 swap_type = BOOT_SWAP_TYPE_FAIL;
             }
+#ifdef INCLUDE_NETWORK_CORE_IMAGE_CHECK
         } else {
             upgrade_valid = true;
+#endif
         }
 
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 \
-    && !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE) && defined(CONFIG_PCD_APP)
+#ifdef INCLUDE_NETWORK_CORE_IMAGE_CHECK
         /* If the update is valid, and it targets the network core: perform the
          * update and indicate to the caller of this function that no update is
          * available
          */
-        if (upgrade_valid && internal_img_addr >= NETCPU_APP_SLOT_OFFSET &&
-            internal_img_addr < NETCPU_APP_SLOT_END) {
+        if (upgrade_valid
+#if defined(CONFIG_MCUBOOT_UUID_CID)
+            && (target_image == CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER)
+#else
+            && (internal_img_addr >= NETCPU_APP_SLOT_OFFSET)
+            && (internal_img_addr < NETCPU_APP_SLOT_END)
+#endif
+            ) {
             struct image_header *hdr = (struct image_header *)secondary_fa->fa_off;
             uint32_t vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
             uint32_t *net_core_fw_addr = (uint32_t *)(vtable_addr);
@@ -1205,12 +1342,12 @@ boot_validated_swap_type(struct boot_loader_state *state,
                 swap_type = BOOT_SWAP_TYPE_NONE;
             }
         }
-#endif /* CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && \
-          !CONFIG_NRF53_MULTI_IMAGE_UPDATE && CONFIG_PCD_APP */
+#endif /* INCLUDE_NETWORK_CORE_IMAGE_CHECK */
     }
 
     return swap_type;
 }
+
 #endif
 
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -246,7 +246,7 @@ boot_slots_compatible(struct boot_loader_state *state)
      * partition manager is in use, and since we have the same sector size
      * in all of our flash.
      */
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && defined(CONFIG_SOC_NRF5340_CPUAPP)
     if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER) {
         return 1;
     }

--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -320,7 +320,7 @@ int boot_slots_compatible(struct boot_loader_state *state)
      * partition manager is in use, and since we have the same sector size
      * in all of our flash.
      */
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && defined(CONFIG_SOC_NRF5340_CPUAPP)
     if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER) {
         return 1;
     }

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -291,7 +291,7 @@ boot_slots_compatible(struct boot_loader_state *state)
      * partition manager is in use, and since we have the same sector size
      * in all of our flash.
      */
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && defined(CONFIG_SOC_NRF5340_CPUAPP)
     if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER) {
         return 1;
     }

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -592,43 +592,50 @@ set(image 0)
 set(auto_min_sectors 0)
 
 while(${image} LESS ${CONFIG_UPDATEABLE_IMAGE_NUMBER})
-  set(slot1_flash)
-  set(slot1_size)
-  set(erase_size_slot1)
-  set(write_size_slot1)
+  set(secondary_slot_flash)
+  set(secondary_slot_size)
+  set(erase_size_secondary_slot)
+  set(write_size_secondary_slot)
   math(EXPR primary_slot "${image} * 2")
 
-  dt_nodelabel(slot0_flash NODELABEL "slot${primary_slot}_partition")
-  if(NOT DEFINED slot0_flash)
+  dt_nodelabel(primary_slot_flash NODELABEL "slot${primary_slot}_partition")
+  if(NOT DEFINED primary_slot_flash)
     message(STATUS "slot${primary_slot}_partition not found. Skip reading erase/write block sizes.")
     math(EXPR image "${image} + 1")
     continue()
   endif()
 
-  dt_get_erase_write_block_sizes(${slot0_flash} erase_size_slot0 write_size_slot0)
+  dt_get_erase_write_block_sizes(${primary_slot_flash} erase_size_primary_slot
+    write_size_primary_slot)
 
   if(CONFIG_BOOT_SWAP_USING_MOVE OR CONFIG_BOOT_SWAP_USING_OFFSET)
-    if(DEFINED erase_size_slot0)
+    if(DEFINED erase_size_primary_slot)
+      if(${image} EQUAL 0)
+        set(erase_size_slot0 ${erase_size_primary_slot})
+      endif()
       zephyr_compile_definitions(
-        "MCUBOOT_SLOT${primary_slot}_EXPECTED_ERASE_SIZE=${erase_size_slot0}")
+        "MCUBOOT_SLOT${primary_slot}_EXPECTED_ERASE_SIZE=${erase_size_primary_slot}")
     endif()
 
-    if(DEFINED write_size_slot0)
+    if(DEFINED write_size_primary_slot)
+      if(${image} EQUAL 0)
+        set(write_size_slot0 ${write_size_primary_slot})
+      endif()
       zephyr_compile_definitions(
-        "MCUBOOT_SLOT${primary_slot}_EXPECTED_WRITE_SIZE=${write_size_slot0}")
+        "MCUBOOT_SLOT${primary_slot}_EXPECTED_WRITE_SIZE=${write_size_primary_slot}")
     endif()
   endif()
 
   if(CONFIG_BOOT_MAX_IMG_SECTORS_AUTO)
-    dt_prop(slot0_size PATH "${slot0_flash}" PROPERTY "reg" INDEX 1)
-    if(DEFINED slot0_size AND DEFINED erase_size_slot0)
-      math(EXPR remainder "${slot0_size} % ${erase_size_slot0}")
+    dt_prop(primary_slot_size PATH "${primary_slot_flash}" PROPERTY "reg" INDEX 1)
+    if(DEFINED primary_slot_size AND DEFINED erase_size_primary_slot)
+      math(EXPR remainder "${primary_slot_size} % ${erase_size_primary_slot}")
       if(NOT remainder EQUAL 0)
-        message(FATAL_ERROR "slot${primary_slot}_partition size (${slot0_size}) is not divisible "
-          "by erase block size (${erase_size_slot0})"
+        message(FATAL_ERROR "slot${primary_slot}_partition size (${primary_slot_size}) is not "
+          "divisible by erase block size (${erase_size_primary_slot})"
         )
       endif()
-      math(EXPR slot_min_sectors "${slot0_size} / ${erase_size_slot0}")
+      math(EXPR slot_min_sectors "${primary_slot_size} / ${erase_size_primary_slot}")
 
       if(${slot_min_sectors} GREATER ${auto_min_sectors})
         set(auto_min_sectors ${slot_min_sectors})
@@ -641,38 +648,44 @@ while(${image} LESS ${CONFIG_UPDATEABLE_IMAGE_NUMBER})
   if(NOT CONFIG_SINGLE_APPLICATION_SLOT AND NOT CONFIG_SINGLE_APPLICATION_SLOT_RAM_LOAD)
     math(EXPR secondary_slot "${primary_slot} + 1")
 
-    dt_nodelabel(slot1_flash NODELABEL "slot${secondary_slot}_partition")
-    if(NOT DEFINED slot1_flash)
+    dt_nodelabel(secondary_slot_flash NODELABEL "slot${secondary_slot}_partition")
+    if(NOT DEFINED secondary_slot_flash)
       message(STATUS
         "slot${secondary_slot}_partition not found. Skip reading erase/write block sizes.")
       math(EXPR image "${image} + 1")
       continue()
     endif()
 
-    dt_get_erase_write_block_sizes(${slot1_flash} erase_size_slot1 write_size_slot1)
+    dt_get_erase_write_block_sizes(${secondary_slot_flash} erase_size_secondary_slot write_size_secondary_slot)
 
     if(CONFIG_BOOT_SWAP_USING_MOVE OR CONFIG_BOOT_SWAP_USING_OFFSET)
-      if(DEFINED erase_size_slot1)
+      if(DEFINED erase_size_secondary_slot)
+        if(${image} EQUAL 0)
+          set(erase_size_slot1 ${erase_size_secondary_slot})
+        endif()
         zephyr_compile_definitions(
-          "MCUBOOT_SLOT${secondary_slot}_EXPECTED_ERASE_SIZE=${erase_size_slot1}")
+          "MCUBOOT_SLOT${secondary_slot}_EXPECTED_ERASE_SIZE=${erase_size_secondary_slot}")
       endif()
 
-      if(DEFINED write_size_slot1)
+      if(DEFINED write_size_secondary_slot)
+        if(${image} EQUAL 0)
+          set(write_size_slot1 ${write_size_secondary_slot})
+        endif()
         zephyr_compile_definitions(
-          "MCUBOOT_SLOT${secondary_slot}_EXPECTED_WRITE_SIZE=${write_size_slot1}")
+          "MCUBOOT_SLOT${secondary_slot}_EXPECTED_WRITE_SIZE=${write_size_secondary_slot}")
       endif()
     endif()
 
     if(CONFIG_BOOT_MAX_IMG_SECTORS_AUTO)
-      dt_prop(slot1_size PATH "${slot1_flash}" PROPERTY "reg" INDEX 1)
-      if(DEFINED slot1_size AND DEFINED erase_size_slot1)
-        math(EXPR remainder "${slot1_size} % ${erase_size_slot1}")
+      dt_prop(secondary_slot_size PATH "${secondary_slot_flash}" PROPERTY "reg" INDEX 1)
+      if(DEFINED secondary_slot_size AND DEFINED erase_size_secondary_slot)
+        math(EXPR remainder "${secondary_slot_size} % ${erase_size_secondary_slot}")
         if(NOT remainder EQUAL 0)
-          message(FATAL_ERROR "slot${secondary_slot}_partition size (${slot1_size}) is not "
-            "divisible by erase block size (${erase_size_slot1})"
+          message(FATAL_ERROR "slot${secondary_slot}_partition size (${secondary_slot_size}) is not "
+            "divisible by erase block size (${erase_size_secondary_slot})"
           )
         endif()
-        math(EXPR slot_min_sectors "${slot1_size} / ${erase_size_slot1}")
+        math(EXPR slot_min_sectors "${secondary_slot_size} / ${erase_size_secondary_slot}")
 
         if(${slot_min_sectors} GREATER ${auto_min_sectors})
           set(auto_min_sectors ${slot_min_sectors})

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1503,8 +1503,9 @@ config MCUBOOT_BOOTUTIL_LIB_OWN_LOG
 
 config MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
         bool "Use load address to verify application is in proper slot"
-		default y if UPDATEABLE_IMAGE_NUMBER > 1 && !PARTITION_MANAGER_ENABLED
-		default y if MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > 0 && !PARTITION_MANAGER_ENABLED
+        depends on !PARTITION_MANAGER_ENABLED
+        default y if !MCUBOOT_UUID_CID && !NRF53_MULTI_IMAGE_UPDATE && \
+		     (UPDATEABLE_IMAGE_NUMBER > 1 || MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > 0)
         help
           The bootloader will use the load address, from the image header,
           to verify that binary is in slot designated for its execution.

--- a/boot/zephyr/uuid/uuid.c
+++ b/boot/zephyr/uuid/uuid.c
@@ -14,15 +14,29 @@ static bool boot_uuid_compare(const struct image_uuid *uuid1, const struct image
 		return false;
 	}
 
-	return memcmp(uuid1->raw, uuid2->raw, ARRAY_SIZE(uuid1->raw)) == 0;
-}
-
-fih_ret boot_uuid_init(void)
-{
-	FIH_RET(FIH_SUCCESS);
+	return memcmp(uuid1->raw, uuid2->raw, sizeof(uuid1->raw)) == 0;
 }
 
 #ifdef CONFIG_MCUBOOT_UUID_VID
+static bool vid_matches_map_entry(const struct image_uuid *vid, const struct uuid_map_entry *entry)
+{
+	const struct uuid_map_entry *vid_map = NULL;
+	size_t n_entries = boot_uuid_vid_map_get(&vid_map);
+
+	if (vid == NULL) {
+		return false;
+	}
+
+	for (size_t i = 0; i < n_entries; i++) {
+		if ((vid_map[i].dev == entry->dev) && (vid_map[i].off == entry->off) &&
+		    (vid_map[i].size == entry->size) && boot_uuid_compare(vid, &vid_map[i].uuid)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 fih_ret boot_uuid_vid_match(const struct flash_area *fap, const struct image_uuid *uuid_vid)
 {
 	const struct uuid_map_entry *map = NULL;
@@ -82,4 +96,50 @@ fih_ret boot_uuid_cid_match(const struct flash_area *fap, const struct image_uui
 
 	FIH_RET(FIH_FAILURE);
 }
+
+int boot_uuid_find_image(const struct image_uuid *cid, const struct image_uuid *vid,
+			 size_t *image_index, size_t *partition_index)
+{
+	const struct uuid_map_entry *cid_map = NULL;
+	size_t n_entries;
+
+	if ((cid == NULL) || (image_index == NULL) || (partition_index == NULL)) {
+		return -EINVAL;
+	}
+
+#ifdef MCUBOOT_UUID_VID
+	if (vid == NULL) {
+		return -EINVAL;
+	}
+#endif
+
+	n_entries = boot_uuid_cid_map_get(&cid_map);
+	if ((n_entries == 0) || (cid_map == NULL)) {
+		return -ENOENT;
+	}
+
+	for (size_t i = 0; i < n_entries; i++) {
+		if (!boot_uuid_compare(cid, &cid_map[i].uuid)) {
+			continue;
+		}
+
+#ifdef MCUBOOT_UUID_VID
+		if (!vid_matches_map_entry(vid, &cid_map[i])) {
+			continue;
+		}
+#endif
+
+		*image_index = cid_map[i].image_index;
+		*partition_index = cid_map[i].partition_index;
+
+		return 0;
+	}
+
+	return -ENOENT;
+}
 #endif /* CONFIG_MCUBOOT_UUID_CID */
+
+fih_ret boot_uuid_init(void)
+{
+	FIH_RET(FIH_SUCCESS);
+}


### PR DESCRIPTION
Use either load_address from the image header or the UUID identification to detect an encrypted MCUboot update candidate image.

manifest-pr-skip