### PR TITLE
[nrf noup] zephyr: Gate RAM unlock on BASE_BOARD_IS_NON_SECURE

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -992,7 +992,7 @@ int main(void)
 /* Lock back PCD used for CPUNET application udapte */
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && \
     defined(CONFIG_PCD_APP)
-#if defined(PM_TFM_SECURE_ADDRESS)
+#if defined(CONFIG_BASE_BOARD_IS_NON_SECURE)
     pcd_lock_ram(false);
 #else
     pcd_lock_ram(true);


### PR DESCRIPTION
Use CONFIG_BASE_BOARD_IS_NON_SECURE instead of CONFIG_BUILD_WITH_TFM to decide whether to leave PCD RAM unlocked, so the condition tracks the non-secure base board variant rather than the TF-M build option.