### PR TITLE
[Backport ncs-v3.4-branch] [nrf noup] boot/zephyr/kconfig: MCUBOOT_CHECK_HEADER_LOAD_ADDRESS=y

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -810,8 +810,11 @@ check_validity:
     if (fap == BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)) {
         struct image_header *secondary_hdr = boot_img_hdr(state, slot);
         uint32_t internal_img_addr = 0; /* either the reset handler addres or the image beginning addres */
-        uint32_t min_addr;
-        uint32_t max_addr;
+        /* min and max addresses for the image are assigned for suppres compiller warnings,
+         * although flow may check them only when they are assigned with other values.
+         */
+        uint32_t min_addr = 0;
+        uint32_t max_addr = 0;
         bool check_addresses = false;
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -814,7 +814,7 @@ check_validity:
         uint32_t max_addr;
         bool check_addresses = false;
 
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
         /* The primary slot for the network core is emulated in RAM.
          * Its flash_area hasn't got relevant boundaries.
          * Therfore need to override its boundaries for the check.

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -605,6 +605,27 @@ boot_rom_address_check(struct boot_loader_state *state)
 }
 #endif
 
+#if (((defined(MCUBOOT_VERIFY_IMG_ADDRESS) && !defined(MCUBOOT_ENC_IMAGES)) \
+  || defined(MCUBOOT_CHECK_HEADER_LOAD_ADDRESS)) ||\
+  defined(MCUBOOT_IS_SECOND_STAGE))
+static void
+get_image_perspective_flash_area_bounds(const struct flash_area *fa, uint32_t *start, uint32_t *end)
+{
+    *start = flash_area_get_off(fa);
+    *end = *start + flash_area_get_size(fa);
+
+    /* For nRF54H20 in a direct-xip mode use relative bounds due to backwards compatibility
+     * For other platforms and modes use absolute bounds.
+     */
+
+    uintptr_t flash_base = 0;
+
+    if (flash_device_base(flash_area_get_device_id(fa), &flash_base) == 0) {
+        *start += (uint32_t)flash_base;
+        *end += (uint32_t)flash_base;
+    }
+}
+#endif
 /*
  * Check that there is a valid image in a slot
  *
@@ -836,8 +857,8 @@ check_validity:
         } else
 #endif
         if (BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER) {
-            min_addr = flash_area_get_off(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY));
-            max_addr = flash_area_get_size(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY)) + min_addr;
+            get_image_perspective_flash_area_bounds(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY),
+                                                    &min_addr, &max_addr);
 
 #ifdef MCUBOOT_IS_SECOND_STAGE
             min_addr = MIN(min_addr, SECOND_STAGE_INACTIVE_MCUBOOT_OFFSET);
@@ -1095,8 +1116,11 @@ boot_validated_swap_type(struct boot_loader_state *state,
                 return BOOT_SWAP_TYPE_FAIL;
             }
 
-            const uint32_t pri_off = flash_area_get_off(primary_fa);
-            const uint32_t pri_end = pri_off + flash_area_get_size(primary_fa);
+            const uint32_t pri_fa_off = flash_area_get_off(primary_fa);
+            uint32_t pri_off;
+            uint32_t pri_end;
+
+            get_image_perspective_flash_area_bounds(primary_fa, &pri_off, &pri_end);
 
             /* Check start and end of primary slot for current image */
             if (internal_img_addr >= SECOND_STAGE_INACTIVE_MCUBOOT_OFFSET &&
@@ -1124,8 +1148,9 @@ boot_validated_swap_type(struct boot_loader_state *state,
                 return BOOT_SWAP_TYPE_NONE;
             }
 
-            if ((pri_off == SECOND_STAGE_ACTIVE_MCUBOOT_OFFSET) ||
-                (pri_off == SECOND_STAGE_INACTIVE_MCUBOOT_OFFSET)) {
+            /* SECOND_STAGE_*_OFFSET is PARTITION_OFFSET (fa_off space), not absolute. */
+            if ((pri_fa_off == SECOND_STAGE_ACTIVE_MCUBOOT_OFFSET) ||
+                (pri_fa_off == SECOND_STAGE_INACTIVE_MCUBOOT_OFFSET)) {
                 NSIB_OWNED_SET(BOOT_CURR_IMG(state));
             }
         }

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1040,11 +1040,17 @@ boot_validated_swap_type(struct boot_loader_state *state,
     FIH_DECLARE(fih_rc, FIH_FAILURE);
     bool upgrade_valid = false;
 
-#if defined(MCUBOOT_IS_SECOND_STAGE) || CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+#if defined(MCUBOOT_IS_SECOND_STAGE) \
+    || (CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 \
+        && (!defined(MCUBOOT_CHECK_HEADER_LOAD_ADDRESS) \
+            || (!defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE) && defined(CONFIG_PCD_APP))))
+    int rc;
     const struct flash_area *secondary_fa = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
+#endif
+
+#if defined(MCUBOOT_IS_SECOND_STAGE) || CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
     struct image_header *hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
     uint32_t internal_img_addr = 0;
-    int rc = 0;
     /* Patch needed for NCS. Since image 0 (the app) and image 1 (the other
      * B1 slot S0 or S1) share the same secondary slot, we need to check
      * whether the update candidate in the secondary slot is intended for

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1490,8 +1490,8 @@ config MCUBOOT_BOOTUTIL_LIB_OWN_LOG
 
 config MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
         bool "Use load address to verify application is in proper slot"
-		default y if UPDATEABLE_IMAGE_NUMBER > 1
-		default y if MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > 0
+		default y if UPDATEABLE_IMAGE_NUMBER > 1 && !PARTITION_MANAGER_ENABLED
+		default y if MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > 0 && !PARTITION_MANAGER_ENABLED
         help
           The bootloader will use the load address, from the image header,
           to verify that binary is in slot designated for its execution.

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1490,6 +1490,8 @@ config MCUBOOT_BOOTUTIL_LIB_OWN_LOG
 
 config MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
         bool "Use load address to verify application is in proper slot"
+		default y if UPDATEABLE_IMAGE_NUMBER > 1
+		default y if MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > 0
         help
           The bootloader will use the load address, from the image header,
           to verify that binary is in slot designated for its execution.
@@ -1506,7 +1508,7 @@ config MCUBOOT_VERIFY_IMG_ADDRESS
 	depends on UPDATEABLE_IMAGE_NUMBER > 1
 	depends on !BOOT_ENCRYPT_IMAGE
 	depends on ARM
-	default y if BOOT_UPGRADE_ONLY
+	default y if BOOT_UPGRADE_ONLY && !MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
 	help
           This option is deprecated, please use MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
           instead.


### PR DESCRIPTION
Backport dcfcd37632c171bf3bfdc454997b7f14e2e7cf87~6..dcfcd37632c171bf3bfdc454997b7f14e2e7cf87 from #684.

this Pr is follow-up to #681