### PR TITLE
[nrf noup] boot/zephyr/kconfig: nrf54h20 default to PSA_CRYPTO

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1574,4 +1574,7 @@ config NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER
 	help
 	  Manufacturing application key identifier.
 
+configdefault PSA_CRYPTO
+	  default y if SOC_NRF54H20 && BOOT_SIGNATURE_TYPE_ED25519
+
 source "Kconfig.zephyr"


### PR DESCRIPTION
CONFIG_PSA_CRYPTO=y by default when MCUboot is build for nRF54h20 and ED25519 signature is selected.