### PR TITLE
[nrf noup] boot: zephyr: sysflash: fprotect size roundup

### DIFF
--- a/boot/zephyr/include/sysflash/pm_sysflash.h
+++ b/boot/zephyr/include/sysflash/pm_sysflash.h
@@ -151,7 +151,8 @@ static inline uint32_t __flash_area_ids_for_slot(int img, int slot)
  */
 #ifdef CONFIG_FPROTECT
 #define FPROTECT_REGION_OFFSET  (PM_S0_ADDRESS)
-#define FPROTECT_REGION_SIZE    (PM_MCUBOOT_PRIMARY_ADDRESS - FPROTECT_REGION_OFFSET)
+#define FPROTECT_REGION_SIZE    \
+    FPROTECT_ALIGN_UP(PM_MCUBOOT_PRIMARY_ADDRESS - FPROTECT_REGION_OFFSET)
 #endif
 
 /* RWX protection regions: the currently executing MCUboot is protecting itself */

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -110,7 +110,8 @@
 #ifdef CONFIG_FPROTECT
 #define FPROTECT_REGION_OFFSET  PARTITION_OFFSET(s0_partition)
 #define FPROTECT_REGION_SIZE    \
-    (PARTITION_SIZE(s0_partition) + PARTITION_SIZE(s1_partition))
+    FPROTECT_ALIGN_UP(PARTITION_SIZE(s0_partition) + \
+                      PARTITION_SIZE(s1_partition))
 #endif
 
 /* RWX protection regions: the currently executing MCUboot is protecting itself */
@@ -184,7 +185,7 @@ static inline uint32_t __flash_area_ids_for_slot(int img, int slot)
 /* Protecting MCUboot partition */
 #ifdef CONFIG_FPROTECT
 #define FPROTECT_REGION_OFFSET  PARTITION_OFFSET(boot_partition)
-#define FPROTECT_REGION_SIZE    PARTITION_SIZE(boot_partition)
+#define FPROTECT_REGION_SIZE    FPROTECT_ALIGN_UP(PARTITION_SIZE(boot_partition))
 #endif
 
 /* RWX protection regions, MCUboot is protecting itself */


### PR DESCRIPTION
adds FPROTECT_ALIGN_UP to FPROTECT_REGION_SIZE
calculation