### PR TITLE
[Backport ncs-v3.4-branch] [nrf noup] boot/zephyr/kconfig: nrf54h20 default to PSA_CRYPTO

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1575,4 +1575,7 @@ config NCS_MCUBOOT_MANUFACTURING_APP_KEY_IDENTIFIER
 	help
 	  Manufacturing application key identifier.
 
+configdefault PSA_CRYPTO
+	  default y if SOC_NRF54H20 && BOOT_SIGNATURE_TYPE_ED25519
+
 source "Kconfig.zephyr"


### PR DESCRIPTION
Backport ed4db63b53e2facb07fe04e87f5568a907091541 from #691.

required for fixingNCSDK-39592