### PR TITLE
[Backport ncs-v3.4-branch] [nrf noup] bootutil: set RSA key bits for PSA OAEP decrypt

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/rsa.h
+++ b/boot/bootutil/include/bootutil/crypto/rsa.h
@@ -121,6 +121,11 @@ bootutil_rsa_parse_private_key(bootutil_rsa_context *ctx, uint8_t **p, uint8_t *
     psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DECRYPT);
     psa_set_key_algorithm(&key_attributes, PSA_ALG_RSA_OAEP(PSA_ALG_SHA_256));
     psa_set_key_type(&key_attributes, PSA_KEY_TYPE_RSA_KEY_PAIR);
+#if defined(MCUBOOT_SIGN_RSA_LEN)
+    psa_set_key_bits(&key_attributes, MCUBOOT_SIGN_RSA_LEN);
+#else
+    psa_set_key_bits(&key_attributes, 2048);
+#endif
 
     status = psa_import_key(&key_attributes, *p, (end - *p), &ctx->key_id);
     return (int)status;


### PR DESCRIPTION
Backport f263a70a3d2c8f1e95c61a1eb7c1abc5ec5e3ea4 from #700.

Basically: fix for non working mcboot's RSA encryption

ref.: NCSDK-39664 (known issue), NCSDK-40114