### PR TITLE
[nrf noup] zephyr/Kconfig: no LOAD_ADDRESS check with QSPI_XIP

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -617,8 +617,11 @@ boot_rom_address_check(struct boot_loader_state *state)
 }
 #endif
 
+/* Netcore slot checks in loader.c are not used with QSPI XIP split images
+ * (see MCUBOOT_QSPI_XIP_IMAGE_NUMBER / MCUBOOT_CHECK_HEADER_LOAD_ADDRESS).
+ */
 #if (CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1) && !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE) \
-    && defined(CONFIG_PCD_APP)
+    && defined(CONFIG_PCD_APP) && (CONFIG_MCUBOOT_QSPI_XIP_IMAGE_NUMBER < 0)
 #define INCLUDE_NETWORK_CORE_IMAGE_CHECK
 #endif
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1505,7 +1505,8 @@ config MCUBOOT_CHECK_HEADER_LOAD_ADDRESS
         bool "Use load address to verify application is in proper slot"
         depends on !PARTITION_MANAGER_ENABLED
         default y if !MCUBOOT_UUID_CID && !NRF53_MULTI_IMAGE_UPDATE && \
-		     (UPDATEABLE_IMAGE_NUMBER > 1 || MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > 0)
+		     (UPDATEABLE_IMAGE_NUMBER > 1 || MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > 0) && \
+		     (MCUBOOT_QSPI_XIP_IMAGE_NUMBER < 0)
         help
           The bootloader will use the load address, from the image header,
           to verify that binary is in slot designated for its execution.


### PR DESCRIPTION
MCUBOOT_CHECK_HEADER_LOAD_ADDRESS shouldn't be use with a qspi-xip image as its partiton addresses could be miss-recognized as a SoC flash partition addresses.

manifest-pr-skip