### PR TITLE
[Backport ncs-v3.4-branch] NCSIDB-1487: Fix nRF53 sequential updates

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -505,9 +505,11 @@ boot_swap_type_multi(int image_index)
     int rc;
     size_t i;
 
+#ifdef CONFIG_NRF53_MULTI_IMAGE_UPDATE
     rc = BOOT_HOOK_CALL(boot_read_swap_state_primary_slot_hook,
                         BOOT_HOOK_REGULAR, image_index, &primary_slot);
     if (rc == BOOT_HOOK_REGULAR)
+#endif
     {
         rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_PRIMARY(image_index),
                                         &primary_slot);

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1354,8 +1354,21 @@ boot_validated_swap_type(struct boot_loader_state *state,
             uint32_t vtable_addr = (uint32_t)hdr + hdr->ih_hdr_size;
             uint32_t *net_core_fw_addr = (uint32_t *)(vtable_addr);
             uint32_t fw_size = hdr->ih_img_size;
+
+#if defined(MCUBOOT_DOWNGRADE_PREVENTION) && defined(CONFIG_SOC_NRF5340_CPUAPP) && \
+    !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE) && defined(CONFIG_PCD_APP) && \
+    defined(CONFIG_PCD_READ_NETCORE_APP_VERSION)
+            BOOT_LOG_INF("Checking network core version");
+            rc = pcd_version_cmp_net(secondary_fa, hdr);
+
+            if (rc >= 0) {
+                BOOT_LOG_INF("Starting network core update");
+                rc = pcd_network_core_update(net_core_fw_addr, fw_size);
+            }
+#else
             BOOT_LOG_INF("Starting network core update");
             rc = pcd_network_core_update(net_core_fw_addr, fw_size);
+#endif
 
             if (rc != 0) {
                 swap_type = BOOT_SWAP_TYPE_FAIL;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -910,6 +910,24 @@ check_validity:
 #endif
 
         BOOT_LOG_DBG("Image %d expected load address 0x%x", BOOT_CURR_IMG(state), internal_img_addr);
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1 && \
+    !defined(CONFIG_NRF53_MULTI_IMAGE_UPDATE)
+        /* If multi image updates are not enabled, the network core update candidate reuses the
+         * secondary slot of the application image.
+         *
+         * This part copies the condition dedicated for the application image (see below) instead of
+         * increasing the allowed range of addresses, so regardless of the partitioning, the
+         * logic will not extend the allowed range to the whole internal (and possibly even
+         * external) memory.
+         */
+        if (check_addresses == true &&
+           BOOT_CURR_IMG(state) == CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER &&
+           internal_img_addr >= NETCPU_APP_SLOT_OFFSET && internal_img_addr < NETCPU_APP_SLOT_END) {
+            BOOT_LOG_INF("Binary in secondary slot of image %d is destined for the network core",
+                         BOOT_CURR_IMG(state));
+            goto out;
+        }
+#endif
         BOOT_LOG_DBG("Check 0x%x is within [min_addr, max_addr] = [0x%x, 0x%x)",
                      internal_img_addr, min_addr, max_addr);
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1133,6 +1133,9 @@ boot_validated_swap_type(struct boot_loader_state *state,
 #ifdef INCLUDE_NETWORK_CORE_IMAGE_CHECK
     bool upgrade_valid = false;
 #endif
+#if defined(INCLUDE_NETWORK_CORE_IMAGE_CHECK) && defined(MCUBOOT_OVERWRITE_ONLY)
+    size_t last_sector;
+#endif
 
 #if defined(INCLUDE_NETWORK_CORE_IMAGE_CHECK) || defined(MCUBOOT_IS_SECOND_STAGE)
     const struct flash_area *secondary_fa = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
@@ -1340,15 +1343,34 @@ boot_validated_swap_type(struct boot_loader_state *state,
                 swap_type = BOOT_SWAP_TYPE_FAIL;
             } else {
                 BOOT_LOG_INF("Done updating network core");
-#if defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE)
-                /* swap_erase_trailer_sectors is undefined if upgrade only
-                 * method is used. There is no need to erase sectors, because
-                 * the image cannot be reverted.
-                 */
-                rc = swap_erase_trailer_sectors(state, secondary_fa);
-#endif
                 swap_type = BOOT_SWAP_TYPE_NONE;
             }
+#if defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE) || \
+    defined(MCUBOOT_SWAP_USING_OFFSET)
+            /* swap_erase_trailer_sectors is undefined if upgrade only
+             * method is used. There is no need to erase sectors, because
+             * the image cannot be reverted.
+             */
+            rc = swap_erase_trailer_sectors(state, secondary_fa);
+#elif defined(MCUBOOT_OVERWRITE_ONLY)
+            /*
+             * Erases header and trailer. The trailer is erased because when a new
+             * image is written without a trailer as is the case when using newt, the
+             * trailer that was left might trigger a new upgrade.
+             */
+#ifndef MCUBOOT_OVERWRITE_ONLY_KEEP_BACKUP
+            BOOT_LOG_DBG("erasing secondary header");
+            rc = boot_scramble_region(secondary_fa,
+                                      boot_img_sector_off(state, BOOT_SLOT_SECONDARY, 0),
+                                      boot_img_sector_size(state, BOOT_SLOT_SECONDARY, 0), false);
+#endif
+            last_sector = boot_img_num_sectors(state, BOOT_SLOT_SECONDARY) - 1;
+            BOOT_LOG_DBG("erasing secondary trailer");
+            rc = boot_scramble_region(secondary_fa,
+                                      boot_img_sector_off(state, BOOT_SLOT_SECONDARY, last_sector),
+                                      boot_img_sector_size(state, BOOT_SLOT_SECONDARY, last_sector),
+                                      false);
+#endif
         }
 #endif /* INCLUDE_NETWORK_CORE_IMAGE_CHECK */
     }


### PR DESCRIPTION
Backport ad892cf561e46efc496ffb186e2341d9feae4e8f~4..ad892cf561e46efc496ffb186e2341d9feae4e8f from #712.