### PR TITLE
[nrf noup] zephyr/Kconfig: reinstatement of BOOT_ECDSA_NRF_OBERON

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -313,8 +313,7 @@ choice BOOT_ECDSA_IMPLEMENTATION
 	default BOOT_ECDSA_TINYCRYPT
 
 config BOOT_ECDSA_NRF_OBERON
-	bool "use nrf oberon SW crypto. [DEPRECATED]"
-	select DEPRECATED
+	bool "use nrf oberon SW crypto"
 	select BOOT_USE_NRF_OBERON
 
 config BOOT_ECDSA_TINYCRYPT


### PR DESCRIPTION
CONFIG_BOOT_ECDSA_NRF_OBERON is important for size optimized SW crypto backend, especially nRF54LS05x SoCs needs such optimization.

ref.: NCSDK-40606