### PR TITLE
[nrf noup] imgtool: Add support for 'auto' to --header-size

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -336,10 +336,24 @@ def validate_security_counter(ctx, param, value):
 
 def validate_header_size(ctx, param, value):
     min_hdr_size = image.IMAGE_HEADER_SIZE
-    if value < min_hdr_size:
+    if value.lower() == 'auto':
+        return min_hdr_size
+
+    if isinstance(value, int):
+       converted = value
+    else:
+       try:
+          converted = int(value, 0)
+       except ValueError:
+           raise click.BadParameter(
+                f"{value} is not a valid integer. Please use code literals "
+                 "prefixed with 0b/0B, 0o/0O, or 0x/0X as necessary."
+                )
+
+    if converted < min_hdr_size:
         raise click.BadParameter(
             f"Minimum value for -H/--header-size is {min_hdr_size}")
-    return value
+    return converted
 
 
 def get_dependencies(ctx, param, value):
@@ -456,8 +470,13 @@ class BasedIntParamType(click.ParamType):
 @click.option('--pad-header', default=False, is_flag=True,
               help='Add --header-size zeroed bytes at the beginning of the '
                    'image')
-@click.option('-H', '--header-size', callback=validate_header_size,
-              type=BasedIntParamType(), required=True)
+@click.option('-H', '--header-size', callback=validate_header_size, required=False,
+              default='auto',
+              help='Unsigned integer in hex, dec or oct format, or auto;'
+                   ' auto will use smallest possible value , rounded up to 32 bits,'
+                   ' capable of storing full header in current version. The auto'
+                   ' is preffered when no address/size requirement are needed for header,'
+                   ' and will give smallest image.')
 @click.option('--pad-sig', default=False, is_flag=True,
               help='Add 0-2 bytes of padding to ECDSA signature '
                    '(for mcuboot <1.5)')


### PR DESCRIPTION
Add 'auto' parameter to --header-size that calculates minimal required header size needed to store all information in current header version. --header-size has been made optional and if not provided, 'auto' will be assumed.
'auto' should not be used if there is specific alignment of executable required, when image is automatically padded, or when image is already shifted internally to required alignment and proper header size is needed for MCUboot to know where to jump while booting the image.

manifest-pr-skip