### PR TITLE
[nrf noup] boot: zephyr: Comma separated BOOT_SIGNATURE_KEY_FILE for 91 only

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -405,8 +405,12 @@ if(CONFIG_MCUBOOT_SERIAL)
 endif()
 
 if(NOT CONFIG_BOOT_SIGNATURE_USING_KMU AND NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
-  # Extract primary key from a potentially comma-separated list.
-  string(REPLACE "," ";" _mcuboot_key_files "${CONFIG_BOOT_SIGNATURE_KEY_FILE}")
+  # Extract primary key; split on comma only when BOOT_SIGNATURE_KEY_FILE_MULTI is enabled.
+  if(CONFIG_BOOT_SIGNATURE_KEY_FILE_MULTI)
+    string(REPLACE "," ";" _mcuboot_key_files "${CONFIG_BOOT_SIGNATURE_KEY_FILE}")
+  else()
+    set(_mcuboot_key_files "${CONFIG_BOOT_SIGNATURE_KEY_FILE}")
+  endif()
   list(GET _mcuboot_key_files 0 _primary_key_path)
 
   # CONF_FILE points to the KConfig configuration files of the bootloader.

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -503,7 +503,7 @@ config NCS_BOOT_SIGNATURE_USING_ITS
 if !BOOT_SIGNATURE_USING_KMU && !NCS_BOOT_SIGNATURE_USING_ITS
 
 config BOOT_SIGNATURE_KEY_FILE
-	string "PEM key file (or comma-separated list)"
+	string "PEM key file (or comma-separated list on nrf91)"
 	depends on !BOOT_SIGNATURE_TYPE_NONE
 	default "root-ec-p256.pem" if BOOT_SIGNATURE_TYPE_ECDSA_P256
 	default "root-ed25519.pem" if BOOT_SIGNATURE_TYPE_ED25519
@@ -515,7 +515,8 @@ config BOOT_SIGNATURE_KEY_FILE
 	  list of PEMs (e.g. "prod_pub.pem,dev_pub.pem") to embed multiple
 	  verification keys in the bootloader. Only the public-key bytes are
 	  ever embedded in the bootloader image regardless of which form is
-	  passed in.
+	  passed in. Comma-separated lists are only supported on nrf91 series
+	  (requires BOOT_SIGNATURE_KEY_FILE_MULTI).
 
 	  The first entry may be either a keypair PEM or a public-only PEM.
 	  A keypair is required only if the same file is also used with
@@ -540,6 +541,14 @@ config BOOT_SIGNATURE_KEY_FILE
 	  MCUboot repository root. Each file is parsed by imgtool's getpub
 	  command and a .c source with the public key information is written
 	  in a format expected by MCUboot.
+
+config BOOT_SIGNATURE_KEY_FILE_MULTI
+	bool
+	default y
+	depends on SOC_SERIES_NRF91
+	help
+	  Enable comma-separated multi-key support in BOOT_SIGNATURE_KEY_FILE.
+	  Restricted to nrf91 series; cannot be enabled for other SoC families.
 
 endif
 

--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -97,14 +97,6 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
     tags: bootloader_mcuboot
-  sample.bootloader.mcuboot.two_signing_keys:
-    extra_configs:
-      - CONFIG_BOOT_SIGNATURE_TYPE_ED25519=y
-      - CONFIG_BOOT_SIGNATURE_KEY_FILE="root-ed25519.pem,root-ed25519-2-pub.pem"
-    platform_allow: nrf52840dk/nrf52840
-    integration_platforms:
-      - nrf52840dk/nrf52840
-    tags: bootloader_mcuboot
   sample.bootloader.mcuboot.runtime_source.hooks:
     extra_args: EXTRA_CONF_FILE=../../samples/runtime-source/zephyr/sample.conf
       TEST_RUNTIME_SOURCE_HOOKS=y


### PR DESCRIPTION
Scope the comma separated BOOT_SIGNATURE_KEY_FILE to only 91 series devices in NCS 3.4.