### PR TITLE
[nrf noup] boot: bootutil: optional_image license

### DIFF
--- a/boot/bootutil/src/optional_image.c
+++ b/boot/bootutil/src/optional_image.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  *
  * Copyright (c) 2026 Nordic Semiconductor ASA
  */


### PR DESCRIPTION
fix license type to Nordic-5-Clause